### PR TITLE
Add package files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[bdist_wheel]
+universal=1
+
+[build_sphinx]
+source-dir = docs
+build-dir  = docs/build
+all_files  = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup, find_packages
+
+setup(name='Mastodon.py',
+      description='Python wrapper for the Mastodon API',
+      packages=['mastodon'],
+      install_requires=['requests'])


### PR DESCRIPTION
This adds a minimal `setup.py` and `setup.cfg`, so that you can do `pip install .` on the repo and it will install as a package, pulling `requests` as needed. You can also do `python setup.py build_sphinx` to generate the docs, provided you have Sphinx.

Keep in mind this isn't really enough to stick this on PyPI, if you wanted to do that.

Tested with 2.7 and 3.5.