### PR TITLE
Error in the documentation: mastodon uses the email address for the login, not the username

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Mastodon.py
    '''
    mastodon = Mastodon(client_id = 'pytooter_clientcred.txt')
    mastodon.log_in(
-       'pytooter', 
+       'my_login_email@example.com',
        'incrediblygoodpassword', 
        to_file = 'pytooter_usercred.txt'
    )


### PR DESCRIPTION
Kind regards,