### PR TITLE
[doc] point to account_search to get user id from address

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -276,6 +276,8 @@ class Mastodon:
         """
         Fetch account information by user id.
 
+        To retreive a user id from it's address (user@instance.com), uses the account_search method.
+
         Returns a user dict.
         """
         return self.__api_request('GET', '/api/v1/accounts/' + str(id))
@@ -292,6 +294,8 @@ class Mastodon:
         """
         Fetch statuses by user id. Same options as timeline are permitted.
 
+        To retreive a user id from it's address (user@instance.com), uses the account_search method.
+
         Returns a list of toot dicts.
         """
         params = self.__generate_params(locals(), ['id'])
@@ -301,6 +305,8 @@ class Mastodon:
         """
         Fetch users the given user is following.
 
+        To retreive a user id from it's address (user@instance.com), uses the account_search method.
+
         Returns a list of user dicts.
         """
         return self.__api_request('GET', '/api/v1/accounts/' + str(id) + '/following')
@@ -308,6 +314,8 @@ class Mastodon:
     def account_followers(self, id):
         """
         Fetch users the given user is followed by.
+
+        To retreive a user id from it's address (user@instance.com), uses the account_search method.
 
         Returns a list of user dicts.
         """
@@ -317,6 +325,8 @@ class Mastodon:
         """
         Fetch relationships (following, followed_by, blocking) of the logged in user to
         a given account. id can be a list.
+
+        To retreive a user id from it's address (user@instance.com), uses the account_search method.
 
         Returns a list of relationship dicts.
         """


### PR DESCRIPTION
Hello,

I don't know if it's the best place to document that, but since I've lost 15 min to find out of the hell I was supposed to get this "numerical id" from an address, that seems to be a good start.

Kind regards,