### PR TITLE
added content_search, probably.

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -332,6 +332,17 @@ class Mastodon:
         """
         params = self.__generate_params(locals())
         return self.__api_request('GET', '/api/v1/accounts/search', params)
+   
+
+    def content_search(self, q, resolve = False):
+        """
+        Fetch matching hashtags, accounts and statuses. Will search federated
+        instances if resolve is True.
+
+        Returns a dict of lists.
+        """
+        params = self.__generate_params(locals())
+        return self.__api_request('GET', '/api/v1/search', params)
 
     ###
     # Reading data: Mutes and Blocks


### PR DESCRIPTION
This seems to work at first sight, with hashtags and accounts being returned, but statuses are always empty for me. Feel free to test this out on other instances and see whether this is a problem with the python code, the instance I'm on or the mastodon API.