### PR TITLE
media_post ValueError

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -565,7 +565,7 @@ class Mastodon:
         Returns a media dict. This contains the id that can be used in
         status_post to attach the media file to a toot.
         """
-        if os.path.isfile(media_file) and mime_type == None:
+        if mime_type == None and os.path.isfile(media_file):
             mime_type = mimetypes.guess_type(media_file)[0]
             media_file = open(media_file, 'rb')
 


### PR DESCRIPTION
Checking if media_type is defined first will short circuit the the call to os.path.isfile when content is supplied with media-file.

Maybe there's a better way to do this, but I'm able to post media now.

fixes #28