### PR TITLE
Remove the mentions timeline because it doesn't exist

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -208,7 +208,6 @@ user could see, as well as hashtag timelines and the public timeline.
 
 .. automethod:: Mastodon.timeline
 .. automethod:: Mastodon.timeline_home
-.. automethod:: Mastodon.timeline_mentions
 .. automethod:: Mastodon.timeline_local
 .. automethod:: Mastodon.timeline_public
 .. automethod:: Mastodon.timeline_hashtag

--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -244,8 +244,8 @@ class Mastodon:
     ##
     def timeline(self, timeline = "home", max_id = None, since_id = None, limit = None):
         """
-        Fetch statuses, most recent ones first. Timeline can be home, mentions, local,
-        public, or tag/hashtag. See the following functions documentation for what those do.
+        Fetch statuses, most recent ones first. Timeline can be home, local, public,
+        or tag/hashtag. See the following functions documentation for what those do.
 
         The default timeline is the "home" timeline.
 
@@ -267,14 +267,6 @@ class Mastodon:
         Returns a list of toot dicts.
         """
         return self.timeline('home', max_id = max_id, since_id = since_id, limit = limit)
-
-    def timeline_mentions(self, max_id = None, since_id = None, limit = None):
-        """
-        Fetches the authenticated users mentions.
-
-        Returns a list of toot dicts.
-        """
-        return self.timeline('mentions', max_id = max_id, since_id = since_id, limit = limit)
 
     def timeline_local(self, max_id = None, since_id = None, limit = None):
         """


### PR DESCRIPTION
I tried to use the mentions timeline and got the `Endpoint not found.` error (on my instance running the latest version of Mastodon).

Looking at the API documentation, it doesn't list the mentions timeline anymore: https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#timelines