### PR TITLE
Fixed clearing notifications raising endpoint not found.

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -592,7 +592,7 @@ class Mastodon:
         """
         Clear out a users notifications
         """
-        return self.__api_request('GET', '/api/v1/notifications/clear')
+        return self.__api_request('POST', '/api/v1/notifications/clear')
 
     ###
     # Writing data: Accounts


### PR DESCRIPTION
This patch is intended to fix #60. Here's what it changes:
- Makes `notifications_clear` function use a `POST` request instead of a `GET` request.