### PR TITLE
Handle case of empty 'Link' header from server

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -957,7 +957,7 @@ class Mastodon:
                 raise MastodonAPIError("Could not parse response as JSON, response code was %s, bad json content was '%s'" % (response_object.status_code, response_object.content))
 
             # Parse link headers
-            if isinstance(response, list) and 'Link' in response_object.headers:
+            if isinstance(response, list) and 'Link' in response_object.headers and response_object.headers['Link'] != "":
                 tmp_urls = requests.utils.parse_header_links(response_object.headers['Link'].rstrip('>').replace('>,<', ',<'))   
                 for url in tmp_urls:
                     if url['rel'] == 'next':


### PR DESCRIPTION
Bug encountered when requesting a list of notifications. If the since_id would result in an empty list, the server returns a response header of Link: "", which the parse link headers logic doesn't know what to do with. This fix avoids that situation by adding an extra entry condition to the block that skips it if the Link header is empty.