### PR TITLE
Send params as part of the query in GET requests

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -923,7 +923,7 @@ class Mastodon:
             response_object = None
             try:
                 if method == 'GET':
-                    response_object = requests.get(self.api_base_url + endpoint, data = params, headers = headers, files = files, timeout = self.request_timeout)
+                    response_object = requests.get(self.api_base_url + endpoint, params = params, headers = headers, files = files, timeout = self.request_timeout)
 
                 if method == 'POST':
                     response_object = requests.post(self.api_base_url + endpoint, data = params, headers = headers, files = files, timeout = self.request_timeout)


### PR DESCRIPTION
Using the data argument will send them form-encoded like for the other requests, which isn't parsed by many servers for GET requests.