### PR TITLE
fix exception in log_in, by accepting json dates as timestamps

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -973,7 +973,10 @@ class Mastodon:
         for k, v in json_object.items():
             if k in known_date_fields:
                 try:
-                    json_object[k] = dateutil.parser.parse(v)
+                    if isinstance(v, int):
+                        json_object[k] = datetime.datetime.fromtimestamp(v, pytz.utc)
+                    else:
+                        json_object[k] = dateutil.parser.parse(v)
                 except:
                     raise MastodonAPIError('Encountered invalid date.')
         return json_object


### PR DESCRIPTION
when requesting a bearer token, mastodon (more specifically doorkeeper)
returns an object with a created_at attribute which is a plain timestamp
unlike in most of mastodon's api:

```json
{
    "access_token": "hunter2",
    "token_type": "bearer",
    "scope": "read write",
    "created_at": 1504824250,
}
```