### PR TITLE
Workaround Mastodon issue with streaming API redirection

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1177,7 +1177,6 @@ class Mastodon:
         # redirection, and then use the domain it gives us to do the final
         # request.
         if endpoint.startswith("/api/v1/streaming"):
-            print("Hi I'm streaming", endpoint)
             stream_base = self.api_base_url + "/api/v1/streaming"
 
             with __no_auth_strip_session() as session:
@@ -1188,7 +1187,6 @@ class Mastodon:
                 raise MastodonNetworkError("Could not connect to streaming server: %s" % connection.reason)
 
             url = connection.url.replace("/api/v1/streaming", endpoint)
-            print("Url redirected:", url)
 
         with __no_auth_strip_session() as session:
             # Prevent stripping of authorisation headers on redirect


### PR DESCRIPTION
Mastodon can be configured to use another address for streaming
server-side. Such a setup is common with certain deployments.

However, due to a bug, Mastodon does not properly issue HTTP redirects
for anything but the endpoint /api/v1/streaming (including subdirs). It
instead gives a 404, causing the request to fail.

The workaround is to hit this path first, checking for any redirects,
and modifying the URL accordingly.

This commit also includes a workaround for behaviour in requests that
causes it to strip the Authorization header from redirected requests.
This is intentional behaviour on the part of requests, but breaks the
redirection done by Mastodon.

Fixes #84