### PR TITLE
Use urlparse instead of urllib.parse for python2.7

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -16,7 +16,10 @@ import dateutil.parser
 import re
 import copy
 import threading
-from urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+     from urlparse import urlparse
 
 
 class Mastodon:
@@ -569,7 +572,7 @@ class Mastodon:
     def toot(self, status):
         """
         Synonym for status_post that only takes the status text as input.
-        
+
         Usage in production code is not recommended.
 
         Returns a toot dict with the new status.
@@ -901,7 +904,7 @@ class Mastodon:
 
         If async is False, this method blocks forever.
 
-        If async is True, 'listener' will listen on another thread and this method 
+        If async is True, 'listener' will listen on another thread and this method
         will return a handle corresponding to the open connection. The
         connection may be closed at any time by calling its close() method.
         """
@@ -914,7 +917,7 @@ class Mastodon:
 
         If async is False, this method blocks forever.
 
-        If async is True, 'listener' will listen on another thread and this method 
+        If async is True, 'listener' will listen on another thread and this method
         will return a handle corresponding to the open connection. The
         connection may be closed at any time by calling its close() method.
         """
@@ -927,7 +930,7 @@ class Mastodon:
 
         If async is False, this method blocks forever.
 
-        If async is True, 'listener' will listen on another thread and this method 
+        If async is True, 'listener' will listen on another thread and this method
         will return a handle corresponding to the open connection. The
         connection may be closed at any time by calling its close() method.
         """
@@ -941,12 +944,12 @@ class Mastodon:
 
         If async is False, this method blocks forever.
 
-        If async is True, 'listener' will listen on another thread and this method 
+        If async is True, 'listener' will listen on another thread and this method
         will return a handle corresponding to the open connection. The
         connection may be closed at any time by calling its close() method.
         """
         return self.__stream("/api/v1/streaming/hashtag?tag={}".format(tag), listener)
-    
+
     ###
     # Internal helpers, dragons probably
     ###
@@ -982,7 +985,7 @@ class Mastodon:
                 except:
                     raise MastodonAPIError('Encountered invalid date.')
         return json_object
-    
+
     def __api_request(self, method, endpoint, params={}, files={}, do_ratelimiting=True):
         """
         Internal API request helper.
@@ -1027,8 +1030,8 @@ class Mastodon:
             response_object = None
             try:
                 if method == 'GET':
-                    response_object = requests.get(self.api_base_url + endpoint, params=params, 
-                                                   headers=headers, files=files, 
+                    response_object = requests.get(self.api_base_url + endpoint, params=params,
+                                                   headers=headers, files=files,
                                                    timeout=self.request_timeout)
                 if method == 'POST':
                     response_object = requests.post(self.api_base_url + endpoint, data=params, headers=headers,
@@ -1058,13 +1061,13 @@ class Mastodon:
                     response = response_object.json()
                 except:
                     raise MastodonAPIError('Endpoint not found.')
-                
+
                 if isinstance(response, dict) and 'error' in response:
                     raise MastodonAPIError("Mastodon API returned error: " + str(response['error']))
                 else:
                     raise MastodonAPIError('Endpoint not found.')
-                
-                
+
+
             if response_object.status_code == 500:
                 raise MastodonAPIError('General API problem.')
 
@@ -1075,11 +1078,11 @@ class Mastodon:
                     "Could not parse response as JSON, response code was %s, "
                     "bad json content was '%s'" % (response_object.status_code,
                                                    response_object.content))
-                    
+
             # See if the returned dict is an error dict even though status is 200
             if isinstance(response, dict) and 'error' in response:
                 raise MastodonAPIError("Mastodon API returned error: " + str(response['error']))
-                    
+
             # Parse link headers
             if isinstance(response, list) and \
                     'Link' in response_object.headers and \


### PR DESCRIPTION
To fix the error:
    from urllib.parse import urlparse
ImportError: No module named parse

when running with python2.7