### PR TITLE
Implement is_alive to async stream

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1305,7 +1305,6 @@ class Mastodon:
         class __stream_handle():
             def __init__(self, connection):
                 self.connection = connection
-                self._thread = threading.current_thread()
 
             def close(self):
                 self.connection.close()
@@ -1314,6 +1313,7 @@ class Mastodon:
                 return self._thread.is_alive()
 
             def _threadproc(self):
+                self._thread = threading.current_thread()
                 with closing(connection) as r:
                     try:
                         listener.handle_stream(r.iter_lines())

--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1305,9 +1305,13 @@ class Mastodon:
         class __stream_handle():
             def __init__(self, connection):
                 self.connection = connection
+                self._thread = threading.current_thread()
 
             def close(self):
                 self.connection.close()
+
+            def is_alive(self):
+                return self._thread.is_alive()
 
             def _threadproc(self):
                 with closing(connection) as r:


### PR DESCRIPTION
When use stream with `async=True`, There is no way to check thread alive.
This PR makes `handle.is_alive()` method to check stream alive. It is useful when user wants to check and restart stream after connection closed.