### PR TITLE
Change str() to encode('utf-8')

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1190,7 +1190,7 @@ class Mastodon:
                     raise MastodonAPIError('Endpoint not found.')
 
                 if isinstance(response, dict) and 'error' in response:
-                    raise MastodonAPIError("Mastodon API returned error: " + str(response['error']))
+                    raise MastodonAPIError("Mastodon API returned error: " + response['error'].encode('utf-8').strip())
                 else:
                     raise MastodonAPIError('Endpoint not found.')
 


### PR DESCRIPTION
Some error don't be displayed with Mastodon.py because it can't convert ascii with str(). So I change str to encode(utf-8)