### PR TITLE
Fix xfail tests

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -7,7 +7,6 @@ def test_id_hook(status):
     assert isinstance(status['id'], int)
 
 
-@pytest.mark.xfail(reason='fixed in upstream')
 @pytest.mark.vcr()
 def test_id_hook_in_reply_to(api, status):
     reply = api.status_post('Reply!', in_reply_to_id=status['id'])

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -45,7 +45,7 @@ def test_toot(api):
 
 @pytest.mark.vcr()
 @pytest.mark.parametrize('visibility', ('', 'direct', 'private', 'unlisted', 'public',
-        pytest.param('foobar', marks=pytest.mark.xfail())))
+        pytest.param('foobar', marks=pytest.mark.xfail(strict=True))))
 @pytest.mark.parametrize('spoiler_text', (None, 'Content warning'))
 def test_status_post(api, visibility, spoiler_text):
     status = api.status_post(


### PR DESCRIPTION
unmarking a test as expected to fail (my branch was behind so it was failing but it's fixed in master)
also making sure that the couple of tests that are supposed to fail are *strictly* xfail