### PR TITLE
Update streaming.py's handle_stream

### DIFF
--- a/mastodon/streaming.py
+++ b/mastodon/streaming.py
@@ -41,26 +41,29 @@ class StreamListener(object):
 
         response; a requests response object with the open stream for reading.
         """
-        event = {}
-        line_buffer = bytearray()
-        for chunk in response.iter_content(chunk_size = 1):
-            if chunk:
-                if chunk == b'\n':
-                    try:
-                        line = line_buffer.decode('utf-8')
-                    except UnicodeDecodeError as err:
-                        six.raise_from(
-                            MastodonMalformedEventError("Malformed UTF-8"),
-                            err
-                        )
-                    if line == '':
-                        self._dispatch(event)
-                        event = {}
+        try:
+            event = {}
+            line_buffer = bytearray()
+            for chunk in response.iter_content(chunk_size = 1):
+                if chunk:
+                    if chunk == b'\n':
+                        try:
+                            line = line_buffer.decode('utf-8')
+                        except UnicodeDecodeError as err:
+                            six.raise_from(
+                                MastodonMalformedEventError("Malformed UTF-8"),
+                                err
+                            )
+                        if line == '':
+                            self._dispatch(event)
+                            event = {}
+                        else:
+                            event = self._parse_line(line, event)
+                        line_buffer = bytearray()
                     else:
-                        event = self._parse_line(line, event)
-                    line_buffer = bytearray()
-                else:
-                    line_buffer.extend(chunk)
+                        line_buffer.extend(chunk)
+        except:
+            pass
         
     def _parse_line(self, line, event):
         if line.startswith(':'):


### PR DESCRIPTION
This is an attempt to resolve an upstream issue with unexpected blank streams. The issue appears to be in urllib3, and causes fatal errors when the stream returned is `b''`. I believe this simple workaround will bypass the error and continue monitoring the stream.