### PR TITLE
Fix 500 from status_post capitalized visibilities

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -929,7 +929,8 @@ class Mastodon:
 
         # Validate visibility parameter
         valid_visibilities = ['private', 'public', 'unlisted', 'direct', '']
-        if params_initial['visibility'].lower() not in valid_visibilities:
+        params_initial['visibility'] = params_initial['visibility'].lower()
+        if params_initial['visibility'] not in valid_visibilities:
             raise ValueError('Invalid visibility value! Acceptable '
                              'values are %s' % valid_visibilities)
 


### PR DESCRIPTION
The validator for the 'visibility' parameter lower()s it before verifying, but this means that "direct", "Direct", and "dIRECT" all pass validation. However, passing in 'Direct' (at least, to my instance) throws `mastodon.Mastodon.MastodonAPIError: ('Mastodon API returned error', 500, 'Internal Server Error', None)`. This corrects the parameter in-place.