### PR TITLE
Remove ''' from example Python code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,13 @@ Mastodon.py
    from mastodon import Mastodon
 
    # Register app - only once!
-   '''
    Mastodon.create_app(
         'pytooterapp',
         api_base_url = 'https://mastodon.social',
         to_file = 'pytooter_clientcred.secret'
    )
-   '''
 
    # Log in - either every time, or use persisted
-   '''
    mastodon = Mastodon(
        client_id = 'pytooter_clientcred.secret',
        api_base_url = 'https://mastodon.social'
@@ -24,7 +21,6 @@ Mastodon.py
        'incrediblygoodpassword',
        to_file = 'pytooter_usercred.secret'
    )
-   '''
 
    # Create actual API instance
    mastodon = Mastodon(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,16 +8,13 @@ Mastodon.py
    from mastodon import Mastodon
 
    # Register app - only once!
-   '''
    Mastodon.create_app(
         'pytooterapp',
         api_base_url = 'https://mastodon.social',
         to_file = 'pytooter_clientcred.secret'
    )
-   '''
 
    # Log in - either every time, or use persisted
-   '''
    mastodon = Mastodon(
        client_id = 'pytooter_clientcred.secret',
        api_base_url = 'https://mastodon.social'
@@ -27,7 +24,6 @@ Mastodon.py
        'incrediblygoodpassword',
        to_file = 'pytooter_usercred.secret'
    )
-   '''
 
    # Create actual API instance
    mastodon = Mastodon(


### PR DESCRIPTION
I think these were leftover from when the docs were in Markdown? As-is, they mean the code samples don't run properly.