### PR TITLE
New exception class if server is malconfigured, e.g. 502

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -2242,6 +2242,8 @@ class Mastodon:
                         # on any 404
                 elif response_object.status_code == 401:
                     ex_type = MastodonUnauthorizedError
+                elif response_object.status_code == 502:
+                    ex_type = MastodonServerError
                 else:
                     ex_type = MastodonAPIError
 
@@ -2526,6 +2528,10 @@ class MastodonReadTimeout(MastodonNetworkError):
 
 class MastodonAPIError(MastodonError):
     """Raised when the mastodon API generates a response that cannot be handled"""
+    pass
+
+class MastodonServerError(MastodonError):
+    """Raised if the Server is malconfigured, e.g. returns a 502 error code"""
     pass
 
 class MastodonNotFoundError(MastodonAPIError):


### PR DESCRIPTION
Hi :) I want to enable more detailed error handling.

If the Server is malconfigured, you can not do much on the Client side - it can be useful to find out whether the API fails because of a 502 or a similar error, or because the Client did something wrong.

502 is the only error code with this problem I have yet encountered in the wild, but others could be added to this Exception class later.

Does this make sense? Are there better ways to build this? I can only speak for my use case.