### PR TITLE
fixing ImportError

### DIFF
--- a/mastodon/__init__.py
+++ b/mastodon/__init__.py
@@ -1,4 +1,4 @@
-from mastodon.Mastodon import Mastodon, AttribAccessDict, MastodonError, MastodonVersionError, MastodonIllegalArgumentError, MastodonIOError, MastodonFileNotFoundError, MastodonNetworkError, MastodonAPIError, MastodonNotFoundError, MastodonUnauthorizedError, MastodonRatelimitError, MastodonMalformedEventError
+from mastodon.Mastodon import Mastodon, AttribAccessDict, MastodonError, MastodonVersionError, MastodonIllegalArgumentError, MastodonIOError, MastodonFileNotFoundError, MastodonNetworkError, MastodonAPIError, MastodonNotFoundError, MastodonUnauthorizedError, MastodonRatelimitError, MastodonMalformedEventError, MastodonServerError
 from mastodon.streaming import StreamListener, CallbackStreamListener
 
 __all__ = ['Mastodon', 'AttribAccessDict', 'StreamListener', 'CallbackStreamListener', 'MastodonError', 'MastodonVersionError', 'MastodonIllegalArgumentError', 'MastodonIOError', 'MastodonFileNotFoundError', 'MastodonNetworkError', 'MastodonAPIError', 'MastodonNotFoundError', 'MastodonUnauthorizedError', 'MastodonRatelimitError', 'MastodonMalformedEventError',


### PR DESCRIPTION
Forgot something at #158, the current release throws this error:

```
Traceback (most recent call last):
  File "/srv/active/mastodonbot.py", line 5, in <module>
    from mastodon import Mastodon, MastodonServerError
AttributeError: module 'mastodon' has no attribute 'MastodonServerError'
```