### PR TITLE
Fix notification dismiss API call

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1801,8 +1801,8 @@ class Mastodon:
         Deletes a single notification
         """
         id = self.__unpack_id(id)
-        params = self.__generate_params(locals())
-        self.__api_request('POST', '/api/v1/notifications/dismiss', params)
+        url = '/api/v1/notifications/{0}/dismiss'.format(str(id))
+        return self.__api_request('POST', url)
 
 
     ###


### PR DESCRIPTION
The old call to /api/v1/notifications/dismiss with the id in a form
parameter is no longer supported. Posting to
/api/v1/notifications/:id/dismiss is the new way to do it.

Fixes #182.