### PR TITLE
filter dicts example used account_follow call

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -488,7 +488,7 @@ Filter dicts
  
 .. code-block:: python
 
-    mastodon.account_follow(<numerical id>)
+    mastodon.filter(<numerical id>)
     # Returns the following dictionary:
     {
         'id': # Numerical id of the filter


### PR DESCRIPTION
The example for Filter Dicts was referencing the `account_follow` function instead of `filter`, probably due to copy/pasting if the previous block?