### PR TITLE
Support tagged, exclude_reblogs parameter on account_statuses

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1028,8 +1028,8 @@ class Mastodon:
         """
         return self.account_verify_credentials()
     
-    @api_version("1.0.0", "2.7.0", __DICT_VERSION_STATUS)
-    def account_statuses(self, id, only_media=False, pinned=False, exclude_replies=False, max_id=None, min_id=None, since_id=None, limit=None):
+    @api_version("1.0.0", "2.8.0", __DICT_VERSION_STATUS)
+    def account_statuses(self, id, only_media=False, pinned=False, exclude_replies=False, max_id=None, min_id=None, since_id=None, limit=None, exclude_reblogs=False, tagged=None):
         """
         Fetch statuses by user `id`. Same options as `timeline()`_ are permitted.
         Returned toots are from the perspective of the logged-in user, i.e.
@@ -1040,6 +1040,8 @@ class Mastodon:
         If `pinned` is set, return only statuses that have been pinned. Note that 
         as of Mastodon 2.1.0, this only works properly for instance-local users.
         If `exclude_replies` is set, filter out all statuses that are replies.
+        If `exclude_reblogs` is set, filter out all statuses that are reblogs.
+        If `tagged` is set, return only statuses that are tagged with `tagged`.
 
         Does not require authentication for Mastodon versions after 2.7.0 (returns
         publicly visible statuses in that case), for publicly visible accounts.
@@ -1063,6 +1065,10 @@ class Mastodon:
             del params["only_media"]
         if exclude_replies == False:
             del params["exclude_replies"]
+        if exclude_reblogs == False:
+            del params["exclude_reblogs"]
+        if tagged is None:
+            del params["tagged"]
         
         url = '/api/v1/accounts/{0}/statuses'.format(str(id))
         return self.__api_request('GET', url, params)


### PR DESCRIPTION
As mastodon API supports this parameters, mastodon.py should support this.