### PR TITLE
Supports a User-Agent header

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,8 @@ def _api(access_token='__MASTODON_PY_TEST_ACCESS_TOKEN', version="3.1.1", versio
             client_secret='__MASTODON_PY_TEST_CLIENT_SECRET',
             access_token=access_token,
             mastodon_version=version,
-            version_check_mode=version_check_mode)
+            version_check_mode=version_check_mode,
+            user_agent='tests/v311')
 
 
 @pytest.fixture


### PR DESCRIPTION
For API requests and connection to the streaming API, Mastodon.py supports now a User-Agent string. The user-agent can be set by the parameter `user_agent` in the constructor, or will be fetched from the application secret file (if available). A change in the implementation of `create_app()` store the app name into the secret file. Mastodon.py uses this information to populate the `User-Agent` string if the user did not pass it to the API via the constructor. 

fixes #213