### PR TITLE
Fix gotosocial crash in search()

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -425,6 +425,10 @@ class Mastodon:
         if not version_check_mode in ["created", "changed", "none"]:
             raise MastodonIllegalArgumentError("Invalid version check method.")
         self.version_check_mode = version_check_mode
+
+        self.mastodon_major = 1
+        self.mastodon_minor = 0
+        self.mastodon_patch = 0
         
         # Versioning
         if mastodon_version == None and self.version_check_mode != 'none':


### PR DESCRIPTION
Set a default 1.0.0 version if nothing else alters it so that version checks don't raise an Exception.

Fixes #249.

Hopefully this is the last thing I find :sweat_smile: 