### PR TITLE
Refactor: use is for None/True/False

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -378,7 +378,7 @@ class Mastodon:
         If no other `User-Agent` is specified, "mastodonpy" will be used.
         """
         self.api_base_url = None
-        if not api_base_url is None:
+        if api_base_url is not None:
             self.api_base_url = Mastodon.__protocolize(api_base_url)
 
         self.client_id = client_id
@@ -419,7 +419,7 @@ class Mastodon:
                     self.client_secret = secret_file.readline().rstrip()
 
                     try_base_url = secret_file.readline().rstrip()
-                    if (not try_base_url is None) and len(try_base_url) != 0:
+                    if try_base_url is not None and len(try_base_url) != 0:
                         try_base_url = Mastodon.__protocolize(try_base_url)
                         if not (self.api_base_url is None or try_base_url == self.api_base_url):
                             raise MastodonIllegalArgumentError(
@@ -440,7 +440,7 @@ class Mastodon:
                 self.access_token = token_file.readline().rstrip()
 
                 try_base_url = token_file.readline().rstrip()
-                if (not try_base_url is None) and len(try_base_url) != 0:
+                if try_base_url is not None and len(try_base_url) != 0:
                     try_base_url = Mastodon.__protocolize(try_base_url)
                     if not (self.api_base_url is None or try_base_url == self.api_base_url):
                         raise MastodonIllegalArgumentError(
@@ -457,7 +457,7 @@ class Mastodon:
         self.version_check_worked = None
 
         # Versioning
-        if mastodon_version == None and self.version_check_mode != 'none':
+        if mastodon_version is None and self.version_check_mode != 'none':
             self.retrieve_mastodon_version()
         elif self.version_check_mode != 'none':
             try:
@@ -865,13 +865,13 @@ class Mastodon:
 
         Returns a list of `toot dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params_initial = locals()
@@ -950,13 +950,13 @@ class Mastodon:
 
         Returns a list of `conversation dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1093,8 +1093,8 @@ class Mastodon:
 
         Returns a list of `notification dicts`_.
         """
-        if not mentions_only is None:
-            if not exclude_types is None:
+        if mentions_only is not None:
+            if exclude_types is not None:
                 if mentions_only:
                     exclude_types = ["follow", "favourite",
                                      "reblog", "poll", "follow_request"]
@@ -1103,16 +1103,16 @@ class Mastodon:
                     'Cannot specify exclude_types when mentions_only is present')
             del mentions_only
 
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
-        if account_id != None:
+        if account_id is not None:
             account_id = self.__unpack_id(account_id)
 
         if id is None:
@@ -1178,13 +1178,13 @@ class Mastodon:
         Returns a list of `toot dicts`_.
         """
         id = self.__unpack_id(id)
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals(), ['id'])
@@ -1208,13 +1208,13 @@ class Mastodon:
         Returns a list of `user dicts`_.
         """
         id = self.__unpack_id(id)
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals(), ['id'])
@@ -1229,13 +1229,13 @@ class Mastodon:
         Returns a list of `user dicts`_.
         """
         id = self.__unpack_id(id)
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals(), ['id'])
@@ -1425,7 +1425,7 @@ class Mastodon:
         Internal Helper: Throw a MastodonVersionError if version is < 2.8.0 but parameters
         for search that are available only starting with 2.8.0 are specified.
         """
-        if not account_id is None or not offset is None or not min_id is None or not max_id is None:
+        if any(item is not None for item in (account_id, offset, min_id, max_id)):
             if self.verify_minimum_version("2.8.0", cached=True) == False:
                 raise MastodonVersionError("Advanced search parameters require Mastodon 2.8.0+")
 
@@ -1554,13 +1554,13 @@ class Mastodon:
         """
         id = self.__unpack_id(id)
 
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals(), ['id'])
@@ -1576,13 +1576,13 @@ class Mastodon:
 
         Returns a list of `user dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1595,13 +1595,13 @@ class Mastodon:
 
         Returns a list of `user dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1632,13 +1632,13 @@ class Mastodon:
 
         Returns a list of `toot dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1654,13 +1654,13 @@ class Mastodon:
 
         Returns a list of `user dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1676,13 +1676,13 @@ class Mastodon:
 
         Returns a list of blocked domain URLs (as strings, without protocol specifier).
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1782,13 +1782,13 @@ class Mastodon:
 
         Returns a list of `toot dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals())
@@ -1857,13 +1857,13 @@ class Mastodon:
 
         Returns a `toot dict`_ with the new status.
         """
-        if quote_id != None:
+        if quote_id is not None:
             if self.feature_set != "fedibird":
                 raise MastodonIllegalArgumentError(
                     'quote_id is only available with feature set fedibird')
             quote_id = self.__unpack_id(quote_id)
 
-        if content_type != None:
+        if content_type is not None:
             if self.feature_set != "pleroma":
                 raise MastodonIllegalArgumentError(
                     'content_type is only available with feature set pleroma')
@@ -1872,23 +1872,23 @@ class Mastodon:
                 raise MastodonIllegalArgumentError(
                     'Invalid content type specified')
 
-        if in_reply_to_id != None:
+        if in_reply_to_id is not None:
             in_reply_to_id = self.__unpack_id(in_reply_to_id)
 
-        if scheduled_at != None:
+        if scheduled_at is not None:
             scheduled_at = self.__consistent_isoformat_utc(scheduled_at)
 
         params_initial = locals()
 
         # Validate poll/media exclusivity
-        if not poll is None:
-            if (not media_ids is None) and len(media_ids) != 0:
+        if poll is not None:
+            if media_ids is not None and len(media_ids) != 0:
                 raise ValueError(
                     'Status can have media or poll attached - not both.')
 
         # Validate visibility parameter
         valid_visibilities = ['private', 'public', 'unlisted', 'direct']
-        if params_initial['visibility'] == None:
+        if params_initial['visibility'] is None:
             del params_initial['visibility']
         else:
             params_initial['visibility'] = params_initial['visibility'].lower()
@@ -1896,14 +1896,14 @@ class Mastodon:
                 raise ValueError('Invalid visibility value! Acceptable '
                                  'values are %s' % valid_visibilities)
 
-        if params_initial['language'] == None:
+        if params_initial['language'] is None:
             del params_initial['language']
 
         if params_initial['sensitive'] is False:
             del [params_initial['sensitive']]
 
         headers = {}
-        if idempotency_key != None:
+        if idempotency_key is not None:
             headers['Idempotency-Key'] = idempotency_key
 
         if media_ids is not None:
@@ -1919,11 +1919,11 @@ class Mastodon:
 
             params_initial["media_ids"] = media_ids_proper
 
-        if params_initial['content_type'] == None:
+        if params_initial['content_type'] is None:
             del params_initial['content_type']
 
         use_json = False
-        if not poll is None:
+        if poll is not None:
             use_json = True
 
         params = self.__generate_params(params_initial, ['idempotency_key'])
@@ -1975,9 +1975,9 @@ class Mastodon:
                          mentioned_accounts.values())) + status
 
         # Retain visibility / cw
-        if visibility == None and 'visibility' in to_status:
+        if visibility is None and 'visibility' in to_status:
             visibility = to_status.visibility
-        if spoiler_text == None and 'spoiler_text' in to_status:
+        if spoiler_text is None and 'spoiler_text' in to_status:
             spoiler_text = to_status.spoiler_text
 
         keyword_args["status"] = status
@@ -2243,7 +2243,7 @@ class Mastodon:
         id = self.__unpack_id(id)
         params = self.__generate_params(locals())
 
-        if params["reblogs"] == None:
+        if params["reblogs"] is None:
             del params["reblogs"]
 
         url = '/api/v1/accounts/{0}/follow'.format(str(id))
@@ -2347,7 +2347,7 @@ class Mastodon:
         params_initial = collections.OrderedDict(locals())
 
         # Convert fields
-        if fields != None:
+        if fields is not None:
             if len(fields) > 4:
                 raise MastodonIllegalArgumentError(
                     'A maximum of four fields are allowed.')
@@ -2366,9 +2366,9 @@ class Mastodon:
 
         # Create file info
         files = {}
-        if not avatar is None:
+        if avatar is not None:
             files["avatar"] = self.__load_media_file(avatar, avatar_mime_type)
-        if not header is None:
+        if header is not None:
             files["header"] = self.__load_media_file(header, header_mime_type)
 
         params = self.__generate_params(params_initial)
@@ -2581,7 +2581,7 @@ class Mastodon:
         """
         account_id = self.__unpack_id(account_id)
 
-        if not status_ids is None:
+        if status_ids is not None:
             if not isinstance(status_ids, list):
                 status_ids = [status_ids]
             status_ids = list(map(lambda x: self.__unpack_id(x), status_ids))
@@ -2653,10 +2653,10 @@ class Mastodon:
         files = {'file': self.__load_media_file(
             media_file, mime_type, file_name)}
 
-        if focus != None:
+        if focus is not None:
             focus = str(focus[0]) + "," + str(focus[1])
 
-        if not thumbnail is None:
+        if thumbnail is not None:
             if not self.verify_minimum_version("3.2.0", cached=True):
                 raise MastodonVersionError(
                     'Thumbnail requires version > 3.2.0')
@@ -2674,7 +2674,7 @@ class Mastodon:
         # Wait for processing?
         if synchronous:
             if self.verify_minimum_version("3.1.4"):
-                while not "url" in ret_dict or ret_dict.url == None:
+                while not "url" in ret_dict or ret_dict.url is None:
                     try:
                         ret_dict = self.media(ret_dict)
                         time.sleep(1.0)
@@ -2697,13 +2697,13 @@ class Mastodon:
         """
         id = self.__unpack_id(id)
 
-        if focus != None:
+        if focus is not None:
             focus = str(focus[0]) + "," + str(focus[1])
 
         params = self.__generate_params(
             locals(), ['id', 'thumbnail', 'thumbnail_mime_type'])
 
-        if not thumbnail is None:
+        if thumbnail is not None:
             if not self.verify_minimum_version("3.2.0", cached=True):
                 raise MastodonVersionError(
                     'Thumbnail requires version > 3.2.0')
@@ -2809,25 +2809,25 @@ class Mastodon:
             'policy': policy
         }
 
-        if follow_events != None:
+        if follow_events is not None:
             params['data[alerts][follow]'] = follow_events
 
-        if favourite_events != None:
+        if favourite_events is not None:
             params['data[alerts][favourite]'] = favourite_events
 
-        if reblog_events != None:
+        if reblog_events is not None:
             params['data[alerts][reblog]'] = reblog_events
 
-        if mention_events != None:
+        if mention_events is not None:
             params['data[alerts][mention]'] = mention_events
 
-        if poll_events != None:
+        if poll_events is not None:
             params['data[alerts][poll]'] = poll_events
 
-        if follow_request_events != None:
+        if follow_request_events is not None:
             params['data[alerts][follow_request]'] = follow_request_events
 
-        if follow_request_events != None:
+        if follow_request_events is not None:
             params['data[alerts][status]'] = status_events
 
         # Canonicalize booleans
@@ -2847,22 +2847,22 @@ class Mastodon:
         """
         params = {}
 
-        if follow_events != None:
+        if follow_events is not None:
             params['data[alerts][follow]'] = follow_events
 
-        if favourite_events != None:
+        if favourite_events is not None:
             params['data[alerts][favourite]'] = favourite_events
 
-        if reblog_events != None:
+        if reblog_events is not None:
             params['data[alerts][reblog]'] = reblog_events
 
-        if mention_events != None:
+        if mention_events is not None:
             params['data[alerts][mention]'] = mention_events
 
-        if poll_events != None:
+        if poll_events is not None:
             params['data[alerts][poll]'] = poll_events
 
-        if follow_request_events != None:
+        if follow_request_events is not None:
             params['data[alerts][follow_request]'] = follow_request_events
 
         # Canonicalize booleans
@@ -2941,13 +2941,13 @@ class Mastodon:
 
         Returns a list of `admin account dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(
@@ -3077,7 +3077,7 @@ class Mastodon:
             send_email_notification = None
 
         id = self.__unpack_id(id)
-        if not report_id is None:
+        if report_id is not None:
             report_id = self.__unpack_id(report_id)
 
         params = self.__generate_params(locals(), ['id', 'action'])
@@ -3097,19 +3097,19 @@ class Mastodon:
 
         Returns a list of `report dicts`_.
         """
-        if max_id != None:
+        if max_id is not None:
             max_id = self.__unpack_id(max_id, dateconv=True)
 
-        if min_id != None:
+        if min_id is not None:
             min_id = self.__unpack_id(min_id, dateconv=True)
 
-        if since_id != None:
+        if since_id is not None:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
-        if not account_id is None:
+        if account_id is not None:
             account_id = self.__unpack_id(account_id)
 
-        if not target_account_id is None:
+        if target_account_id is not None:
             target_account_id = self.__unpack_id(target_account_id)
 
         if resolved == False:
@@ -3444,7 +3444,7 @@ class Mastodon:
         """
         Fetch the logged in user's ID, with caching. ID is reset on calls to log_in.
         """
-        if self.__logged_in_id == None:
+        if self.__logged_in_id is None:
             self.__logged_in_id = self.account_verify_credentials().id
         return self.__logged_in_id
 
@@ -3467,7 +3467,7 @@ class Mastodon:
                              "updated_at", "last_status_at", "starts_at", "ends_at", "published_at", "edited_at"]
         for k, v in json_object.items():
             if k in known_date_fields:
-                if v != None:
+                if v is not None:
                     try:
                         if isinstance(v, int):
                             json_object[k] = datetime.datetime.fromtimestamp(v, pytz.utc)
@@ -3555,9 +3555,9 @@ class Mastodon:
 
         # Generate request headers
         headers = copy.deepcopy(headers)
-        if not self.access_token is None:
+        if self.access_token is not None:
             headers['Authorization'] = 'Bearer ' + self.access_token
-        if not access_token_override is None:
+        if access_token_override is not None:
             headers['Authorization'] = 'Bearer ' + access_token_override
 
         # Add user-agent
@@ -3566,7 +3566,7 @@ class Mastodon:
 
         # Determine base URL
         base_url = self.api_base_url
-        if not base_url_override is None:
+        if base_url_override is not None:
             base_url = base_url_override
 
         if self.debug_requests:
@@ -3626,7 +3626,7 @@ class Mastodon:
                     ratelimit_intrep = None
 
                 try:
-                    if not ratelimit_intrep is None and ratelimit_intrep == response_object.headers['X-RateLimit-Reset']:
+                    if ratelimit_intrep is not None and ratelimit_intrep == response_object.headers['X-RateLimit-Reset']:
                         self.ratelimit_reset = int(
                             response_object.headers['X-RateLimit-Reset'])
                     else:
@@ -3871,7 +3871,7 @@ class Mastodon:
 
             def close(self):
                 self.closed = True
-                if not self.connection is None:
+                if self.connection is not None:
                     self.connection.close()
 
             def is_alive(self):
@@ -3897,7 +3897,7 @@ class Mastodon:
 
                 # Run until closed or until error if not autoreconnecting
                 while self.running:
-                    if not self.connection is None:
+                    if self.connection is not None:
                         with closing(self.connection) as r:
                             try:
                                 listener.handle_stream(r)

--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -632,7 +632,7 @@ class Mastodon:
         self.__logged_in_id = None
 
         # Retry version check if needed (might be required in limited federation mode)
-        if self.version_check_worked == False:
+        if not self.version_check_worked:
             self.retrieve_mastodon_version()
 
         return response['access_token']
@@ -698,7 +698,7 @@ class Mastodon:
         params['client_id'] = self.client_id
         params['client_secret'] = self.client_secret
 
-        if agreement == False:
+        if not agreement:
             del params['agreement']
 
         # Step 1: Get a user-free token via oauth
@@ -876,13 +876,13 @@ class Mastodon:
 
         params_initial = locals()
 
-        if local == False:
+        if not local:
             del params_initial['local']
 
-        if remote == False:
+        if not remote:
             del params_initial['remote']
 
-        if only_media == False:
+        if not only_media:
             del params_initial['only_media']
 
         if timeline == "local":
@@ -1188,13 +1188,13 @@ class Mastodon:
             since_id = self.__unpack_id(since_id, dateconv=True)
 
         params = self.__generate_params(locals(), ['id'])
-        if pinned == False:
+        if not pinned:
             del params["pinned"]
-        if only_media == False:
+        if not only_media:
             del params["only_media"]
-        if exclude_replies == False:
+        if not exclude_replies:
             del params["exclude_replies"]
-        if exclude_reblogs == False:
+        if not exclude_reblogs:
             del params["exclude_reblogs"]
 
         url = '/api/v1/accounts/{0}/statuses'.format(str(id))
@@ -1359,7 +1359,7 @@ class Mastodon:
                 continue
 
             filter_string = re.escape(keyword_filter["phrase"])
-            if keyword_filter["whole_word"] == True:
+            if keyword_filter["whole_word"]:
                 filter_string = "\\b" + filter_string + "\\b"
             filter_strings.append(filter_string)
         filter_re = re.compile("|".join(filter_strings), flags=re.IGNORECASE)
@@ -1426,7 +1426,7 @@ class Mastodon:
         for search that are available only starting with 2.8.0 are specified.
         """
         if any(item is not None for item in (account_id, offset, min_id, max_id)):
-            if self.verify_minimum_version("2.8.0", cached=True) == False:
+            if not self.verify_minimum_version("2.8.0", cached=True):
                 raise MastodonVersionError("Advanced search parameters require Mastodon 2.8.0+")
 
     @api_version("1.1.0", "2.8.0", __DICT_VERSION_SEARCHRESULT)
@@ -1455,7 +1455,7 @@ class Mastodon:
 
         Returns a `search result dict`_, with tags as `hashtag dicts`_.
         """
-        if self.verify_minimum_version("2.4.1", cached=True) == True:
+        if self.verify_minimum_version("2.4.1", cached=True):
             return self.search_v2(q, resolve=resolve, result_type=result_type, account_id=account_id, offset=offset, min_id=min_id, max_id=max_id)
         else:
             self.__ensure_search_params_acceptable(
@@ -1471,7 +1471,7 @@ class Mastodon:
         Returns a `search result dict`_.
         """
         params = self.__generate_params(locals())
-        if resolve == False:
+        if not resolve:
             del params['resolve']
         return self.__api_request('GET', '/api/v1/search', params)
 
@@ -1489,10 +1489,10 @@ class Mastodon:
             account_id, offset, min_id, max_id)
         params = self.__generate_params(locals())
 
-        if resolve == False:
+        if not resolve:
             del params["resolve"]
 
-        if exclude_unreviewed == False or not self.verify_minimum_version("3.0.0", cached=True):
+        if not exclude_unreviewed or not self.verify_minimum_version("3.0.0", cached=True):
             del params["exclude_unreviewed"]
 
         if "result_type" in params:
@@ -2587,7 +2587,7 @@ class Mastodon:
             status_ids = list(map(lambda x: self.__unpack_id(x), status_ids))
 
         params_initial = locals()
-        if forward == False:
+        if not forward:
             del params_initial['forward']
 
         params = self.__generate_params(params_initial)
@@ -2953,7 +2953,7 @@ class Mastodon:
         params = self.__generate_params(
             locals(), ['remote', 'status', 'staff_only'])
 
-        if remote == True:
+        if remote:
             params["remote"] = True
 
         mod_statuses = ["active", "pending",
@@ -2961,7 +2961,7 @@ class Mastodon:
         if not status in mod_statuses:
             raise ValueError("Invalid moderation status requested.")
 
-        if staff_only == True:
+        if staff_only:
             params["staff"] = True
 
         for mod_status in mod_statuses:
@@ -3073,7 +3073,7 @@ class Mastodon:
         if action is None:
             action = "none"
 
-        if send_email_notification == False:
+        if not send_email_notification:
             send_email_notification = None
 
         id = self.__unpack_id(id)
@@ -3112,7 +3112,7 @@ class Mastodon:
         if target_account_id is not None:
             target_account_id = self.__unpack_id(target_account_id)
 
-        if resolved == False:
+        if not resolved:
             resolved = None
 
         params = self.__generate_params(locals())
@@ -3269,12 +3269,12 @@ class Mastodon:
         # Figure out what size to decode to
         decode_components_x, decode_components_y = blurhash.components(
             media_dict["blurhash"])
-        if size_per_component == False:
-            decode_size_x = out_size[0]
-            decode_size_y = out_size[1]
-        else:
+        if size_per_component:
             decode_size_x = decode_components_x * out_size[0]
             decode_size_y = decode_components_y * out_size[1]
+        else:
+            decode_size_x = out_size[0]
+            decode_size_y = out_size[1]
 
         # Decode
         decoded_image = blurhash.decode(
@@ -3584,13 +3584,12 @@ class Mastodon:
             response_object = None
             try:
                 kwargs = dict(headers=headers, files=files, timeout=self.request_timeout)
-                if use_json == False:
-                    if method == 'GET':
-                        kwargs['params'] = params
-                    else:
-                        kwargs['data'] = params
-                else:
+                if use_json:
                     kwargs['json'] = params
+                elif method == 'GET':
+                    kwargs['params'] = params
+                else:
+                    kwargs['data'] = params
 
                 # Block list with exactly three entries, matching on hashes of the instance API domain
                 # For more information, have a look at the docs
@@ -3679,7 +3678,7 @@ class Mastodon:
                             request_complete = False
                             continue
                 
-                if skip_error_check == False:
+                if not skip_error_check:
                     if response_object.status_code == 404:
                         ex_type = MastodonNotFoundError
                         if not error_msg:
@@ -3708,7 +3707,7 @@ class Mastodon:
             if return_response_object:
                 return response_object
 
-            if parse == True:
+            if parse:
                 try:
                     response = response_object.json(
                         object_hook=self.__json_hooks)
@@ -3968,10 +3967,8 @@ class Mastodon:
 
         param_keys = list(params.keys())
         for key in param_keys:
-            if isinstance(params[key], bool) and params[key] == False:
-                params[key] = '0'
-            if isinstance(params[key], bool) and params[key] == True:
-                params[key] = '1'
+            if isinstance(params[key], bool):
+                params[key] = '1' if params[key] else '0'
 
         for key in param_keys:
             if params[key] is None or key in exclude:

--- a/mastodon/streaming.py
+++ b/mastodon/streaming.py
@@ -213,11 +213,11 @@ class CallbackStreamListener(StreamListener):
         self.status_update_handler = status_update_handler
 
     def on_update(self, status):
-        if self.update_handler != None:
+        if self.update_handler is not None:
             self.update_handler(status)
 
         try:
-            if self.local_update_handler != None and not "@" in status["account"]["acct"]:
+            if self.local_update_handler is not None and not "@" in status["account"]["acct"]:
                 self.local_update_handler(status)
         except Exception as err:
             six.raise_from(
@@ -226,21 +226,21 @@ class CallbackStreamListener(StreamListener):
             )
 
     def on_delete(self, deleted_id):
-        if self.delete_handler != None:
+        if self.delete_handler is not None:
             self.delete_handler(deleted_id)
 
     def on_notification(self, notification):
-        if self.notification_handler != None:
+        if self.notification_handler is not None:
             self.notification_handler(notification)
 
     def on_conversation(self, conversation):
-        if self.conversation_handler != None:
+        if self.conversation_handler is not None:
             self.conversation_handler(conversation)
 
     def on_unknown_event(self, name, unknown_event=None):
-        if self.unknown_event_handler != None:
+        if self.unknown_event_handler is not None:
             self.unknown_event_handler(name, unknown_event)
 
     def on_status_update(self, status):
-        if self.status_update_handler != None:
+        if self.status_update_handler is not None:
             self.status_update_handler(status)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -252,7 +252,7 @@ def test_featured_tags(api):
         assert featured_tag_list[0].name == "coolfree"
         assert "url" in featured_tag_list[0]
     finally:
-        if not featured_tag is None:
+        if featured_tag is not None:
             api.featured_tag_delete(featured_tag)
         api.featured_tag_delete(featured_tag_2) 
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -4,7 +4,7 @@ import pytest
 def test_bookmarks(api, status):
     status_bookmarked = api.status_bookmark(status)
     assert status_bookmarked
-    assert status_bookmarked.bookmarked == True
+    assert status_bookmarked.bookmarked
     
     bookmarked_statuses = api.bookmarks()
     assert bookmarked_statuses
@@ -18,7 +18,7 @@ def test_bookmarks(api, status):
 
     status_unbookmarked = api.status_unbookmark(status_bookmarked)
     assert status_unbookmarked
-    assert status_unbookmarked.bookmarked == False
+    assert not status_unbookmarked.bookmarked
     
     bookmarked_statuses_2 = api.bookmarks()
     assert bookmarked_statuses_2 is not None

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -21,6 +21,6 @@ def test_bookmarks(api, status):
     assert status_unbookmarked.bookmarked == False
     
     bookmarked_statuses_2 = api.bookmarks()
-    assert not bookmarked_statuses_2 is None
+    assert bookmarked_statuses_2 is not None
     assert len(bookmarked_statuses_2) == len(bookmarked_statuses) - 1
     

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -33,9 +33,9 @@ def test_constructor_missing_client_secret():
 
 @pytest.mark.vcr()
 def test_verify_version(api):
-    assert api.verify_minimum_version("2.3.3") == True
-    assert api.verify_minimum_version("9999.9999.9999") == False
-    assert api.verify_minimum_version("1.0.0") == True
+    assert api.verify_minimum_version("2.3.3") is True
+    assert api.verify_minimum_version("9999.9999.9999") is False
+    assert api.verify_minimum_version("1.0.0") is True
     
 def test_supported_version(api):
     assert Mastodon.get_supported_version()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,12 +7,12 @@ def test_filter_create(api):
     with vcr.use_cassette('test_filter_create.yaml', cassette_library_dir='tests/cassettes_pre_4_0_0', record_mode='none'):
         keyword_filter = api.filter_create("anime", ['notifications'], irreversible = False, whole_word = True, expires_in = None)
         try:
-            assert(keyword_filter)
+            assert keyword_filter
             
             all_filters = api.filters()
-            assert(keyword_filter in all_filters)
-            assert(keyword_filter.irreversible == False)
-            assert(keyword_filter.whole_word == True)
+            assert keyword_filter in all_filters
+            assert keyword_filter.irreversible is False
+            assert keyword_filter.whole_word is True
             
             keyword_filter_2 = api.filter(keyword_filter.id)
             assert(keyword_filter == keyword_filter_2)
@@ -22,9 +22,9 @@ def test_filter_create(api):
     
         keyword_filter = api.filter_create("anime", ['notifications'], irreversible = False, whole_word = False, expires_in = None)
         try:
-            assert(keyword_filter)
-            assert(keyword_filter.irreversible == False)
-            assert(keyword_filter.whole_word == False)
+            assert keyword_filter
+            assert keyword_filter.irreversible is False
+            assert keyword_filter.whole_word is False
             
             all_filters = api.filters()
             assert(keyword_filter in all_filters)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -32,7 +32,7 @@ def test_date_hook(status):
 
 @pytest.mark.vcr()
 def test_attribute_access(status):
-    assert status.id != None
+    assert status.id is not None
     with pytest.raises(AttributeError):
         status.id = 420
     

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -38,7 +38,7 @@ def test_emoji(api):
 
 @pytest.mark.vcr()
 def test_health(api):
-    assert api.instance_health() == True
+    assert api.instance_health() is True
 
 @pytest.mark.vcr()
 def test_server_time(api):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -45,7 +45,7 @@ def test_media_post(api, sensitive):
     time.sleep(10)
     media2 = api.media(media)
     assert media2.id == media.id
-    assert not media2.url is None
+    assert media2.url is not None
 
     status = api.status_post(
         'LOL check this out',

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -21,7 +21,7 @@ def test_media_post_v1(api):
         assert status
 
         try:
-            assert status['sensitive'] == False
+            assert status['sensitive'] is False
             assert status['media_attachments']
             assert status['media_attachments'][0]['description'] == "John Lennon doing a funny walk"
             assert status['media_attachments'][0]['meta']['focus']['x'] == -0.5

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -29,7 +29,7 @@ def test_notifications_dismiss_pre_2_9_2(api, api2):
             api.verify_minimum_version("2.9.2", cached=False)
             api.notifications_dismiss(notifications[0])
         finally:
-            if not status is None:
+            if status is not None:
                 api2.status_delete(status)            
 
 @pytest.mark.vcr()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -57,14 +57,14 @@ def test_push_update(api):
     print(sub3)
     print(api.push_subscription())
     
-    assert sub3.alerts.follow == False
-    assert sub3.alerts.favourite == False
-    assert sub3.alerts.reblog == False
-    assert sub3.alerts.mention == False
-    assert sub2.alerts.follow == True
-    assert sub2.alerts.favourite == True
-    assert sub2.alerts.reblog == True
-    assert sub2.alerts.mention == True
+    assert sub3.alerts.follow is False
+    assert sub3.alerts.favourite is False
+    assert sub3.alerts.reblog is False
+    assert sub3.alerts.mention is False
+    assert sub2.alerts.follow is True
+    assert sub2.alerts.favourite is True
+    assert sub2.alerts.reblog is True
+    assert sub2.alerts.mention is True
   
 
 @pytest.mark.vcr(match_on=['path'])

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -20,7 +20,7 @@ close_connections = False
 def patch_streaming():
     global streaming_is_patched
     global close_connections
-    if streaming_is_patched == True:
+    if streaming_is_patched is True:
         return
     streaming_is_patched = True
     
@@ -35,7 +35,7 @@ def patch_streaming():
                 response = real_connection_real_get_response(*args, **kwargs)
                 real_body = b""
                 try:
-                    while close_connections == False:
+                    while close_connections is False:
                         if len(select.select([response], [], [], 0.01)[0]) > 0:
                             chunk = response.read(1)
                             real_body += chunk
@@ -165,7 +165,7 @@ def test_unknown_event():
         'data: {}',
         '',
     ])
-    assert listener.bla_called == True
+    assert listener.bla_called is True
     assert listener.updates == []
     assert listener.notifications == []
     assert listener.deletes == []
@@ -195,7 +195,7 @@ def test_dotted_unknown_event():
         'data: {}',
         '',
     ])
-    assert listener.do_something_called == True
+    assert listener.do_something_called is True
     assert listener.updates == []
     assert listener.notifications == []
     assert listener.deletes == []

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -60,8 +60,8 @@ def test_conversations(api, api2):
     assert conversations
     assert status.id in map(lambda x: x.last_status.id, conversations)
     assert account.id in map(lambda x: x.accounts[0].id, conversations)
-    assert conversations[0].unread == True
-    assert conversations2[0].unread == False
+    assert conversations[0].unread is True
+    assert conversations2[0].unread is False
 
 @pytest.mark.vcr()
 def test_min_max_id(api, status):


### PR DESCRIPTION
Just wondering whether you'd like to get some help in refactoring the code to make it more compact and easier to read/extend. I have a few more ideas I could bring in futher PRs. If you do not like it, please feel free to close this PR.

This PR fixes the comparison of `None`, `True`, and `False`, where `is`/`is not` instead of `==`/`!=` should be used.