### PR TITLE
fix NameError: name 'x' is not defined in __json_date_parse()

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -3569,7 +3569,7 @@ class Mastodon:
                         else:
                             json_object[k] = dateutil.parser.parse(v)
                     except:
-                        if isinstance(v, str) and len(x.strip()) == 0:
+                        if isinstance(v, str) and len(v.strip()) == 0:
                             # Pleroma bug workaround: Empty string becomes start of epoch
                             json_object[k] = datetime.datetime.fromtimestamp(0)
                         else:


### PR DESCRIPTION
this was introduced with the recent changes to fix #271 

(side comment: btw, with respect to the #271 fix, wouldn't make more sense to replace empty date strings with null/None instead of start of epoch?)