### PR TITLE
Added missing verified_at attribute when updating profile fields with account_update_credentials

### DIFF
--- a/mastodon/accounts.py
+++ b/mastodon/accounts.py
@@ -427,10 +427,10 @@ class Mastodon(Internals):
                 raise MastodonIllegalArgumentError(
                     'A maximum of four fields are allowed.')
 
-            fields_attributes = []
-            for idx, (field_name, field_value) in enumerate(fields):
+            for idx, (field_name, field_value, field_verified_at) in enumerate(fields):
                 params_initial[f'fields_attributes[{idx}][name]'] = field_name
                 params_initial[f'fields_attributes[{idx}][value]'] = field_value
+                params_initial[f'fields_attributes[{idx}][verified_at]'] = field_verified_at
 
         # Clean up params
         for param in ["avatar", "avatar_mime_type", "header", "header_mime_type", "fields"]:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -119,8 +119,8 @@ def test_account_update_credentials(api):
         header = image,
         header_mime_type = "image/jpeg",
         fields = [
-            ("bread", "toasty."),
-            ("lasagna", "no!!!"),
+            ("bread", "toasty.", None),
+            ("lasagna", "no!!!", None),
         ]
     )
     
@@ -136,11 +136,11 @@ def test_account_update_credentials(api):
 def test_account_update_credentials_too_many_fields(api):
     with pytest.raises(MastodonIllegalArgumentError):
         api.account_update_credentials(fields = [
-            ('a', 'b'),
-            ('c', 'd'), 
-            ('e', 'f'), 
-            ('g', 'h'), 
-            ('i', 'j'),
+            ('a', 'b', 'c'),
+            ('d', 'e', 'f'), 
+            ('g', 'h', 'i'), 
+            ('j', 'k', 'l'), 
+            ('m', 'n', 'o'),
         ])
 
 @pytest.mark.vcr(match_on=['path'])


### PR DESCRIPTION
Consider the following code snippet where I retrieve user's profile fields and then update them using the same values.


```python
import os
from mastodon import Mastodon

mastodon = Mastodon(access_token = os.environ.get('MASTODON_ACCESS_TOKEN'), api_base_url = os.environ.get('MASTODON_INSTANCE'), request_timeout = 100)
result = mastodon.account_verify_credentials()
profile_fields = result['fields']

profile_fields_tuples = []

for row in profile_fields:
  profile_fields_tuples.append(tuple(list(row.values())))

result = mastodon.account_update_credentials(fields = profile_fields_tuples)
```

This will throw the following error:

```
ValueError: too many values to unpack (expected 2)
```

This is due to a missing `verified_at` attribute inside the `account_update_credentials` function.


It will also be necessary to [update the documentation](https://mastodonpy.readthedocs.io/en/stable/15_everything.html?highlight=account_update_credentials#mastodon.Mastodon.account_update_credentials) to reflect  this change.
