### PR TITLE
Add README to PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from setuptools import setup
 
 test_deps = [
@@ -26,9 +28,14 @@ extras = {
     "blurhash": blurhash_deps,
 }
 
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.rst").read_text()
+
 setup(name='Mastodon.py',
       version='1.8.0',
       description='Python wrapper for the Mastodon API',
+      long_description=long_description,
+      long_description_content_type='text/x-rst',
       packages=['mastodon'],
       install_requires=[
           'requests>=2.4.2', 


### PR DESCRIPTION
Currently the PyPI page (https://pypi.org/project/Mastodon.py/) has no project description:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1324225/222949582-0a61303b-1036-4142-853d-79936df8f311.png">

A common thing to do is put the contents of the README, for example:

* https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
