### PR TITLE
Clarify the use of 'code' in log_in()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,15 @@ Feature complete for public API as of Mastodon version 3.5.5 and easy to get sta
         to_file = 'pytooter_usercred.secret'
     )
 
+    # If you are logging in for the first time you need to give permissions to the app
+    # via OAuth, at the URL given by auth_request_url() and then pass code instead of
+    # username and password.
+    mastodon.log_in(
+            to_file = 'pytooter_usercred.secret', 
+            code='code_from_oauth,
+            scopes=['read', 'write'],
+        )
+
     # Note that this won't work when using 2FA - you'll have to use OAuth, in that case. 
     # To post, create an actual API instance:
     mastodon = Mastodon(access_token = 'pytooter_usercred.secret')

--- a/mastodon/authentication.py
+++ b/mastodon/authentication.py
@@ -315,7 +315,7 @@ class Mastodon(Internals):
         For OAuth 2, obtain a code via having your user go to the URL returned by
         :ref:`auth_request_url() <auth_request_url()>` and pass it as the code parameter. In this case,
         make sure to also pass the same redirect_uri parameter as you used when
-        generating the auth request URL.
+        generating the auth request URL. If passing `code`you should not pass `username` or `password`.
 
         Returns the access token as a string.
         """


### PR DESCRIPTION
Now it's not clear that if you pass a username and password to log_in() the params['grant_type'] in authentication.py will be set to "password" and the log in attempt will throw a MastodonIllegalArgumentError because of invalid grant.