### PR TITLE
remove six dependecy

### DIFF
--- a/mastodon/streaming.py
+++ b/mastodon/streaming.py
@@ -4,7 +4,6 @@ https://github.com/mastodon/documentation/blob/master/content/en/methods/timelin
 """
 
 import json
-import six
 try:
     from inspect import signature
 except:
@@ -131,10 +130,7 @@ class StreamListener(object):
                                 exception = MastodonMalformedEventError(
                                     "Malformed UTF-8")
                                 self.on_abort(exception)
-                                six.raise_from(
-                                    exception,
-                                    err
-                                )
+                                raise exception from err
                             if line == '':
                                 self._dispatch(event)
                                 event = {}
@@ -146,26 +142,17 @@ class StreamListener(object):
         except ChunkedEncodingError as err:
             exception = MastodonNetworkError("Server ceased communication.")
             self.on_abort(exception)
-            six.raise_from(
-                exception,
-                err
-            )
+            raise exception from err
         except ReadTimeout as err:
             exception = MastodonReadTimeout(
                 "Timed out while reading from server."),
             self.on_abort(exception)
-            six.raise_from(
-                exception,
-                err
-            )
+            raise exception from err
         except ConnectionError as err:
             exception = MastodonNetworkError(
                 "Requests reports connection error."),
             self.on_abort(exception)
-            six.raise_from(
-                exception,
-                err
-            )
+            raise exception from err
 
     def _parse_line(self, line, event):
         if line.startswith(':'):
@@ -200,19 +187,13 @@ class StreamListener(object):
             exception = MastodonMalformedEventError(
                 'Missing field', err.args[0], event)
             self.on_abort(exception)
-            six.raise_from(
-                exception,
-                err
-            )
+            raise exception from err
         except ValueError as err:
             # py2: plain ValueError
             # py3: json.JSONDecodeError, a subclass of ValueError
             exception = MastodonMalformedEventError('Bad JSON', data)
             self.on_abort(exception)
-            six.raise_from(
-                exception,
-                err
-            )
+            raise exception from err
 
         # New mastodon API also supports event names with dots,
         # specifically, status_update.
@@ -287,10 +268,7 @@ class CallbackStreamListener(StreamListener):
             if self.local_update_handler is not None and not "@" in status["account"]["acct"]:
                 self.local_update_handler(status)
         except Exception as err:
-            six.raise_from(
-                MastodonMalformedEventError('received bad update', status),
-                err
-            )
+            raise MastodonMalformedEventError('received bad update', status) from err
 
     def on_delete(self, deleted_id):
         if self.delete_handler is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
     'requests>=2.4.2',
     'python-dateutil',
-    'six',
     'python-magic-bin ; platform_system=="Windows"',
     'python-magic ; platform_system!="Windows"',
     'decorator>=4.0.0',

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -94,6 +94,9 @@ class Listener(StreamListener):
 
     def handle_stream_(self, lines):
         """Test helper to avoid littering all tests with six.b()."""
+        def six_b(s):
+            return s.encode("latin-1")
+
         class MockResponse():
             def __init__(self, data):
                 self.data = data
@@ -105,7 +108,7 @@ class Listener(StreamListener):
                         bytearr.append(byte)
                         yield(bytearr)
                     yield(b'\n')
-        return self.handle_stream(MockResponse(map(bytes, lines)))
+        return self.handle_stream(MockResponse(map(six_b, lines)))
 
 
 def test_heartbeat():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,4 +1,3 @@
-import six
 import pytest
 import itertools
 from mastodon.streaming import StreamListener, CallbackStreamListener
@@ -98,7 +97,7 @@ class Listener(StreamListener):
         class MockResponse():
             def __init__(self, data):
                 self.data = data
-                
+
             def iter_content(self, chunk_size):
                 for line in self.data:
                     for byte in line:
@@ -106,7 +105,7 @@ class Listener(StreamListener):
                         bytearr.append(byte)
                         yield(bytearr)
                     yield(b'\n')
-        return self.handle_stream(MockResponse(map(six.b, lines)))
+        return self.handle_stream(MockResponse(map(bytes, lines)))
 
 
 def test_heartbeat():


### PR DESCRIPTION
six was once usefull to support python 2 & 3 with the same codebase

https://wiki.debian.org/Python3-six-removal