### PR TITLE
Format docstring for visibility parameter

### DIFF
--- a/mastodon/statuses.py
+++ b/mastodon/statuses.py
@@ -199,15 +199,16 @@ class Mastodon(Internals):
         should be marked as sensitive, which hides it by default on the Mastodon
         web front-end.
 
-        The visibility parameter is a string value and accepts any of:
-        'direct' - post will be visible only to mentioned users
-        'private' - post will be visible only to followers
-        'unlisted' - post will be public but not appear on the public timeline
-        'public' - post will be public
+        The `visibility` parameter is a string value and accepts any of:
+        
+        * ``'direct'`` - post will be visible only to **mentioned users**
+        * ``'private'`` - post will be visible only to **followers**
+        * ``'unlisted'`` - post will be **public but not appear on the public timeline**
+        * ``'public'`` - post will be **public**
 
-        If not passed in, visibility defaults to match the current account's
+        If not passed in, `visibility` defaults to match the current account's
         default-privacy setting (starting with Mastodon version 1.6) or its
-        locked setting - private if the account is locked, public otherwise
+        locked setting - ``'private'`` if the account is locked, ``'public'`` otherwise
         (for Mastodon versions lower than 1.6).
 
         The `spoiler_text` parameter is a string to be shown as a warning before

--- a/mastodon/statuses.py
+++ b/mastodon/statuses.py
@@ -201,11 +201,12 @@ class Mastodon(Internals):
 
         The `visibility` parameter is a string value and accepts any of:
         
-        * ``'direct'`` - post will be visible only to **mentioned users**
-        * ``'private'`` - post will be visible only to **followers**
-        * ``'unlisted'`` - post will be **public but not appear on the public timeline**
-        * ``'public'`` - post will be **public**
+        * ``'direct'`` - post will be visible only to **mentioned users**, known in Mastodon's UI as "Mentioned users only"
+        * ``'private'`` - post will be visible only to **followers**, known in Mastodon's UI as "Followers only"
+        * ``'unlisted'`` - post will be public but **will not appear** on the public timelines
+        * ``'public'`` - post will be public and **will appear** on public timelines
 
+\
         If not passed in, `visibility` defaults to match the current account's
         default-privacy setting (starting with Mastodon version 1.6) or its
         locked setting - ``'private'`` if the account is locked, ``'public'`` otherwise


### PR DESCRIPTION
Without this change it is easy to get confused while reading the online docs.

https://mastodonpy.readthedocs.io/en/stable/05_statuses.html#status-post