### PR TITLE
Add API call for getting multiple accounts at once

### DIFF
--- a/docs/06_accounts.rst
+++ b/docs/06_accounts.rst
@@ -15,6 +15,7 @@ Reading
 .. automethod:: Mastodon.account
 .. automethod:: Mastodon.account_search
 .. automethod:: Mastodon.account_lookup
+.. automethod:: Mastodon.accounts
 
 .. automethod:: Mastodon.featured_tags
 .. automethod:: Mastodon.featured_tag_suggestions

--- a/docs/15_everything.rst
+++ b/docs/15_everything.rst
@@ -51,6 +51,7 @@ Every function on a huge CTRL-F-able page
 .. automethod:: Mastodon.account
 .. automethod:: Mastodon.account_search
 .. automethod:: Mastodon.account_lookup
+.. automethod:: Mastodon.accounts
 .. automethod:: Mastodon.featured_tags
 .. automethod:: Mastodon.featured_tag_suggestions
 .. automethod:: Mastodon.account_featured_tags

--- a/mastodon/accounts.py
+++ b/mastodon/accounts.py
@@ -84,7 +84,7 @@ class Mastodon(Internals):
             self.access_token = response['access_token']
             self.__set_refresh_token(response.get('refresh_token'))
             self.__set_token_expired(int(response.get('expires_in', 0)))
-        except Exception as e:
+        except Exception:
             raise MastodonIllegalArgumentError('Invalid request')
 
         # Step 3: Check scopes, persist, et cetera
@@ -132,6 +132,16 @@ class Mastodon(Internals):
         """
         id = self.__unpack_id(id)
         return self.__api_request('GET', f'/api/v1/accounts/{id}')
+
+    @api_version("4.3.0", "4.3.0", _DICT_VERSION_ACCOUNT)
+    def accounts(self, ids: List[Union[Account, IdType]]) -> List[Account]:
+        """
+        Fetch information from multiple accounts by a list of user `id`.
+
+        Does not require authentication for publicly visible accounts.
+        """
+        ids = [self.__unpack_id(id) for id in ids]
+        return self.__api_request('GET', '/api/v1/accounts', {"id": ids})
 
     @api_version("1.0.0", "2.1.0", _DICT_VERSION_ACCOUNT)
     def account_verify_credentials(self) -> Account:
@@ -255,7 +265,7 @@ class Mastodon(Internals):
         """
         params = self.__generate_params(locals())
 
-        if params["following"] == False:
+        if params["following"] is False:
             del params["following"]
 
         return self.__api_request('GET', '/api/v1/accounts/search', params)

--- a/mastodon/accounts.py
+++ b/mastodon/accounts.py
@@ -141,7 +141,7 @@ class Mastodon(Internals):
         Does not require authentication for publicly visible accounts.
         """
         ids = [self.__unpack_id(id) for id in ids]
-        return self.__api_request('GET', '/api/v1/accounts', {"id": ids})
+        return self.__api_request('GET', '/api/v1/accounts', {"id[]": ids})
 
     @api_version("1.0.0", "2.1.0", _DICT_VERSION_ACCOUNT)
     def account_verify_credentials(self) -> Account:

--- a/mastodon/accounts.py
+++ b/mastodon/accounts.py
@@ -84,7 +84,7 @@ class Mastodon(Internals):
             self.access_token = response['access_token']
             self.__set_refresh_token(response.get('refresh_token'))
             self.__set_token_expired(int(response.get('expires_in', 0)))
-        except Exception:
+        except Exception as e:
             raise MastodonIllegalArgumentError('Invalid request')
 
         # Step 3: Check scopes, persist, et cetera
@@ -265,7 +265,7 @@ class Mastodon(Internals):
         """
         params = self.__generate_params(locals())
 
-        if params["following"] is False:
+        if params["following"] == False:
             del params["following"]
 
         return self.__api_request('GET', '/api/v1/accounts/search', params)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -9,6 +9,15 @@ def test_account(api):
     assert account
 
 @pytest.mark.vcr()
+def test_accounts(api):
+    account_ids = [
+        api.account_lookup("mastodonpy_test").id, 
+        api.account_lookup("mastodonpy_test_2").id
+    ]
+    accounts = api.accounts(account_ids)
+    assert len(accounts) == 2
+
+@pytest.mark.vcr()
 def test_verify_credentials(api):
     account_a = api.account_verify_credentials()
     account_b = api.me()


### PR DESCRIPTION
Fixes https://github.com/halcy/Mastodon.py/issues/384

I have added support for the 4.3.0 API [webhook](https://docs.joinmastodon.org/methods/accounts/#index) that allows to pull multiple accounts in a single call.

I have tested this locally and seems to work, I've also added a test (not sure if it's a good one). 

Please feel free to give some directions in case there is something wrong, as this is the first time I try and contribute to this project. 