### PR TITLE
[minor] Remove "unpacking" + commented `print` statement

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../'))
 autodoc_member_order = 'bysource'
-# print(sys.path)
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/mastodon/internals.py
+++ b/mastodon/internals.py
@@ -533,7 +533,8 @@ class Mastodon():
         # and we basically always want it
         for key in param_keys:
             if key in ['min_id', 'max_id', 'since_id']:
-                print("Unpacking", key)
+                if self.debug_requests:
+                    print("Unpacking", key)
                 params[key] = self.__unpack_id(params[key], dateconv = dateconv, listify = False)
 
         return params

--- a/mastodon/internals.py
+++ b/mastodon/internals.py
@@ -533,8 +533,6 @@ class Mastodon():
         # and we basically always want it
         for key in param_keys:
             if key in ['min_id', 'max_id', 'since_id']:
-                if self.debug_requests:
-                    print("Unpacking", key)
                 params[key] = self.__unpack_id(params[key], dateconv = dateconv, listify = False)
 
         return params

--- a/mastodon/types_base.py
+++ b/mastodon/types_base.py
@@ -209,7 +209,6 @@ def try_cast(t, value, retry = True, union_specializer = None):
     * Trying once again to AttribAccessDict as a fallback
     Gives up and returns as-is if none of the above work.
     """
-    #print("Cast attempt: ", value, "to", t)
     if value is None: # None early out
         return value
     t = resolve_type(t)
@@ -271,7 +270,6 @@ def try_cast(t, value, retry = True, union_specializer = None):
             else:
                 value = t(value)
     except Exception as e:
-        #print("Failed to cast", value, "to", t, ":", e)
         if retry and isinstance(value, dict):
             value = try_cast(AttribAccessDict, value, False, union_specializer)
     return value
@@ -333,20 +331,17 @@ def try_cast_recurse(t, value, union_specializer=None):
     except Exception as e:
         # Failures are silently ignored. We care about maximum not breaking here.
         pass
-    
-    #print("Type casted", value, "to", t)
+
     if real_issubclass(value.__class__, AttribAccessDict) or real_issubclass(value.__class__, PaginatableList) or real_issubclass(value.__class__, NonPaginatableList) or real_issubclass(value.__class__, MaybeSnowflakeIdType):
         save_type = t
         if real_type is not None and use_real_type:
             save_type = real_type
-        #print("And trying to add _mastopy_type as ", save_type)
         try:
             # Unsure how robust this is - to be evaluated
             value._mastopy_type = repr(save_type).replace("mastodon.return_types.", "").replace("mastodon.types_base.", "")
             if value._mastopy_type.startswith("<class '") and value._mastopy_type.endswith("'>"):
                 value._mastopy_type = value._mastopy_type[8:-2]
         except Exception as e:
-            #print("Failed to set _mastopy_type:", e)
             # Failures are silently ignored. We care about maximum not breaking here.
             pass
     return value

--- a/mastodon/utility.py
+++ b/mastodon/utility.py
@@ -34,7 +34,6 @@ class Mastodon(Internals):
             version_str = self.__normalize_version_string(self.__instance()["version"])
             self.version_check_worked = True
         except Exception as e:
-            print(e)
             # instance() was added in 1.1.0, so our best guess is 1.0.0.
             version_str = "1.0.0"
             self.version_check_worked = False


### PR DESCRIPTION
While working on a personal project that consumes `mastodon.py`, I stumbled upon a printed statement that was not being outputted by my loggers saying `Unpacking min_id`:

![Screenshot 2025-02-25 at 9 40 59 PM](https://github.com/user-attachments/assets/41ef7f4c-4a51-41c8-8c9c-c7f1361ef755)

After some checks, I found that it's coming from the `internals.py` file. I see that there are multiple other `print` statements and all are being wrapped by the `self.debug_requests` variable so I added that check here as well.