### PR TITLE
Use bounded type variables for pagination utility methods

### DIFF
--- a/mastodon/utility.py
+++ b/mastodon/utility.py
@@ -1,5 +1,6 @@
 # utility.py - utility functions, externally usable
 
+from typing import TypeVar
 import re
 import dateutil
 import datetime
@@ -19,6 +20,7 @@ from mastodon.types_base import Entity, try_cast
 from ._url_regex import url_regex
 import unicodedata
 
+_T = TypeVar("_T", bound=Entity)
 
 class Mastodon(Internals):
     def set_language(self, lang: str):
@@ -147,7 +149,7 @@ class Mastodon(Internals):
     ###
     # Pagination
     ###
-    def fetch_next[T: Entity](self, previous_page: Union[PaginatableList[T], T, PaginationInfo]) -> Optional[Union[PaginatableList[T], T]]:
+    def fetch_next(self, previous_page: Union[PaginatableList[_T], _T, PaginationInfo]) -> Optional[Union[PaginatableList[_T], _T]]:
         """
         Fetches the next page of results of a paginated request. Pass in the
         previous page in its entirety, or the pagination information dict
@@ -195,7 +197,7 @@ class Mastodon(Internals):
         else:
             return self.__api_request(method, endpoint, params, override_type=response_type)
 
-    def fetch_previous[T: Entity](self, next_page: Union[PaginatableList[T], T, PaginationInfo]) -> Optional[Union[PaginatableList[T], T]]:
+    def fetch_previous(self, next_page: Union[PaginatableList[_T], _T, PaginationInfo]) -> Optional[Union[PaginatableList[_T], _T]]:
         """
         Fetches the previous page of results of a paginated request. Pass in the
         previous page in its entirety, or the pagination information dict
@@ -243,7 +245,7 @@ class Mastodon(Internals):
         else:
             return self.__api_request(method, endpoint, params, override_type=response_type)
 
-    def fetch_remaining[T: Entity](self, first_page: PaginatableList[T]) -> PaginatableList[T]:
+    def fetch_remaining(self, first_page: PaginatableList[_T]) -> PaginatableList[_T]:
         """
         Fetches all the remaining pages of a paginated request starting from a
         first page and returns the entire set of results (including the first page
@@ -281,7 +283,7 @@ class Mastodon(Internals):
         else:
             return None
 
-    def pagination_iterator[T: Entity](self, start_page: Union[PaginatableList[T], PaginationInfo], direction: str = "next", return_pagination_info: bool = False) -> Iterator[T]:
+    def pagination_iterator(self, start_page: Union[PaginatableList[_T], PaginationInfo], direction: str = "next", return_pagination_info: bool = False) -> Iterator[_T]:
         """
         Returns an iterator that will yield all entries in a paginated request,
         starting from the given start_page (can also be just the PaginationInfo, in which case the

--- a/mastodon/utility.py
+++ b/mastodon/utility.py
@@ -147,7 +147,7 @@ class Mastodon(Internals):
     ###
     # Pagination
     ###
-    def fetch_next(self, previous_page: Union[PaginatableList[Entity], Entity, PaginationInfo]) -> Optional[Union[PaginatableList[Entity], Entity]]:
+    def fetch_next[T: Entity](self, previous_page: Union[PaginatableList[T], T, PaginationInfo]) -> Optional[Union[PaginatableList[T], T]]:
         """
         Fetches the next page of results of a paginated request. Pass in the
         previous page in its entirety, or the pagination information dict
@@ -195,7 +195,7 @@ class Mastodon(Internals):
         else:
             return self.__api_request(method, endpoint, params, override_type=response_type)
 
-    def fetch_previous(self, next_page: Union[PaginatableList[Entity], Entity, PaginationInfo]) -> Optional[Union[PaginatableList[Entity], Entity]]:
+    def fetch_previous[T: Entity](self, next_page: Union[PaginatableList[T], T, PaginationInfo]) -> Optional[Union[PaginatableList[T], T]]:
         """
         Fetches the previous page of results of a paginated request. Pass in the
         previous page in its entirety, or the pagination information dict
@@ -243,7 +243,7 @@ class Mastodon(Internals):
         else:
             return self.__api_request(method, endpoint, params, override_type=response_type)
 
-    def fetch_remaining(self, first_page: PaginatableList[Entity]) -> PaginatableList[Entity]:
+    def fetch_remaining[T: Entity](self, first_page: PaginatableList[T]) -> PaginatableList[T]:
         """
         Fetches all the remaining pages of a paginated request starting from a
         first page and returns the entire set of results (including the first page
@@ -281,7 +281,7 @@ class Mastodon(Internals):
         else:
             return None
 
-    def pagination_iterator(self, start_page: Union[PaginatableList[Entity], PaginationInfo], direction: str = "next", return_pagination_info: bool = False) -> Iterator[Entity]:
+    def pagination_iterator[T: Entity](self, start_page: Union[PaginatableList[T], PaginationInfo], direction: str = "next", return_pagination_info: bool = False) -> Iterator[T]:
         """
         Returns an iterator that will yield all entries in a paginated request,
         starting from the given start_page (can also be just the PaginationInfo, in which case the


### PR DESCRIPTION
This should resolve the conversation we had under #421.

Quoting here for reference:

---

**@thcrt** [commented](https://github.com/halcy/Mastodon.py/pull/421#issuecomment-3309682494):

> [Another] type-checking snag I've run into:
>
> ```python
> api = MastodonAPI(...)
> followers = api.fetch_remaining(api.account_followers(api.me()))
> ```
> 
> This code causes Pyright to complain:
> 
> ```
> error: Argument of type "PaginatableList[Account]" cannot be assigned to parameter "first_page" of type "PaginatableList[Entity]" in function "fetch_remaining"
>     "PaginatableList[Account]" is not assignable to "PaginatableList[Entity]"
>       Type parameter "T@PaginatableList" is invariant, but "Account" is not the same as "Entity" (reportArgumentType)
> ```

**@halcy** [commented](https://github.com/halcy/Mastodon.py/pull/421#issuecomment-3317965262):

> Thinking about it a bit: I _think_ the most correct solution would be to introduce a typevar in utility.py and use that in the signatures for fetch_next / fetch_prev / fetch_remaining to indicate that if you pass in a List of T, you get out a List of T.
