### PR TITLE
Fix UnboundLocalError in streaming API URL parsing

### DIFF
--- a/mastodon/internals.py
+++ b/mastodon/internals.py
@@ -386,14 +386,14 @@ class Mastodon():
         if not streaming_api_url is None and streaming_api_url != self.api_base_url:
             # This is probably a websockets URL, which is really for the browser, but requests can't handle it
             # So we do this below to turn it into an HTTPS or HTTP URL
-            parse = urlparse(instance["urls"]["streaming_api"])
+            parse = urlparse(streaming_api_url)
             if parse.scheme == 'wss':
                 url = "https://" + parse.netloc
             elif parse.scheme == 'ws':
                 url = "http://" + parse.netloc
             else:
                 raise MastodonAPIError(
-                    f"Could not parse streaming api location returned from server: {instance['urls']['streaming_api']}."
+                    f"Could not parse streaming api location returned from server: {streaming_api_url}."
                 )
         else:
             url = self.api_base_url


### PR DESCRIPTION
This PR fixes an UnboundLocalError that occurs when calling stream_public() and other streaming endpoints.

When calling mastodon.stream_public(), the following error is raised:
```
  Traceback (most recent call last):
    File "/home/nicky/repos/mastodon-crawler/mastodon_crawler/get_stream.py", line 151, in <module>
      crawl(args)
      ~~~~~^^^^^^
    File "/home/nicky/repos/mastodon-crawler/mastodon_crawler/get_stream.py", line 82, in crawl
      handle = func(listener, run_async=True, reconnect_async=True)
    File "/home/nicky/repos/mastodon-crawler/.venv/lib/python3.13/site-packages/decorator.py", line 235, in fun
      return caller(func, *(extras + args), **kw)
    File "/home/nicky/repos/mastodon-crawler/.venv/lib/python3.13/site-packages/mastodon/versions.py", line 50, in wrapper
      return function(self, *args, **kwargs)
    File "/home/nicky/repos/mastodon-crawler/.venv/lib/python3.13/site-packages/mastodon/streaming_endpoints.py", line 37, in stream_public
      return self.__stream(base, listener, run_async=run_async, timeout=timeout, reconnect_async=reconnect_async, reconnect_async_wait_sec=reconnect_async_wait_sec)
             ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/nicky/repos/mastodon-crawler/.venv/lib/python3.13/site-packages/mastodon/internals.py", line 412, in __stream
      url = self.__get_streaming_base()
    File "/home/nicky/repos/mastodon-crawler/.venv/lib/python3.13/site-packages/mastodon/internals.py", line 389, in __get_streaming_base
      parse = urlparse(instance["urls"]["streaming_api"])
                       ^^^^^^^^
  UnboundLocalError: cannot access local variable 'instance' where it is not associated with a value
```