### PR TITLE
Make blurhash and python-magic{-bin} optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,7 @@ classifiers = [
 dependencies = [
     'requests>=2.4.2',
     'python-dateutil',
-    'python-magic-bin ; platform_system=="Windows"',
-    'python-magic ; platform_system!="Windows"',
     'decorator>=4.0.0',
-    'blurhash>=1.1.4',
 ]
 
 [project.optional-dependencies]
@@ -39,6 +36,10 @@ blurhash = [
 ]
 grapheme = [
     'graphemeu>=0.7.2',
+]
+magic = [
+    'python-magic-bin ; platform_system=="Windows"',
+    'python-magic ; platform_system!="Windows"',
 ]
 test = [
     'pytest',


### PR DESCRIPTION
I believe this is necessary to make these two packages actually optional deps.
c/f conda-forge/mastodon.py-feedstock/pull/30
c/f conda-forge/staged-recipes/pull/32104