### PR TITLE
cleanup imports

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1,37 +1,14 @@
 # coding: utf-8
 
-import json
-import base64
-import os
-import os.path
-import time
-import datetime
-import collections
-from contextlib import closing
-import requests
-from requests.models import urlencode
-import dateutil
-import dateutil.parser
-import re
-import copy
 
 
-from mastodon.compat import IMPL_HAS_CRYPTO, IMPL_HAS_ECE, IMPL_HAS_BLURHASH
-from mastodon.compat import cryptography, default_backend, ec, serialization
-from mastodon.compat import http_ece
-from mastodon.compat import blurhash
-from mastodon.compat import urlparse
 
-from mastodon.utility import parse_version_string, max_version, api_version
 from mastodon.utility import Mastodon as MastoUtility
 
 from mastodon.return_types import *
 from mastodon.errors import *
 
-from mastodon.defaults import _DEFAULT_TIMEOUT, _DEFAULT_SCOPES, _DEFAULT_STREAM_TIMEOUT, _DEFAULT_STREAM_RECONNECT_WAIT_SEC
-from mastodon.defaults import _SCOPE_SETS
 
-from mastodon.internals import Mastodon as Internals
 from mastodon.authentication import Mastodon as MastoAuthentication
 from mastodon.accounts import Mastodon as MastoAccounts
 from mastodon.instance import Mastodon as MastoInstance

--- a/mastodon/authentication.py
+++ b/mastodon/authentication.py
@@ -7,12 +7,11 @@ import os
 import time
 import collections
 
-from mastodon.errors import MastodonIllegalArgumentError, MastodonNetworkError, MastodonVersionError, MastodonAPIError, MastodonNotFoundError
+from mastodon.errors import MastodonIllegalArgumentError, MastodonNetworkError, MastodonVersionError, MastodonAPIError
 from mastodon.defaults import _DEFAULT_SCOPES, _SCOPE_SETS, _DEFAULT_TIMEOUT, _DEFAULT_USER_AGENT
 from mastodon.utility import parse_version_string, api_version
 
 from mastodon.internals import Mastodon as Internals
-from mastodon.utility import Mastodon as Utility
 from typing import List, Optional, Union, Tuple
 from mastodon.return_types import Application, AttribAccessDict, OAuthServerInfo, OAuthUserInfo
 from mastodon.compat import PurePath

--- a/mastodon/favourites.py
+++ b/mastodon/favourites.py
@@ -4,7 +4,7 @@ from mastodon.utility import api_version
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import Status, IdType, PaginatableList
 
-from typing import Optional, Union
+from typing import Optional
 
 class Mastodon(Internals):
     ###

--- a/mastodon/media.py
+++ b/mastodon/media.py
@@ -8,7 +8,7 @@ from mastodon.utility import api_version
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import MediaAttachment, PathOrFile, IdType
 
-from typing import Optional, Union, Tuple, List, Dict, Any
+from typing import Optional, Union, Tuple
 
 class Mastodon(Internals):
     ###

--- a/mastodon/return_types.py
+++ b/mastodon/return_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations # python< 3.9 compat
 from datetime import datetime
-from typing import Union, Optional, Tuple, List, IO, Dict
-from mastodon.types_base import AttribAccessDict, IdType, MaybeSnowflakeIdType, PaginationInfo, PrimitiveIdType, EntityList, PaginatableList, NonPaginatableList, PathOrFile, WebpushCryptoParamsPubkey, WebpushCryptoParamsPrivkey, try_cast_recurse, try_cast, real_issubclass
+from typing import Union, Optional
+from mastodon.types_base import AttribAccessDict, IdType, MaybeSnowflakeIdType, PaginationInfo, NonPaginatableList
 
 class Account(AttribAccessDict):
     """

--- a/mastodon/streaming.py
+++ b/mastodon/streaming.py
@@ -9,7 +9,6 @@ try:
 except:
     pass
 
-from mastodon import Mastodon
 from mastodon.Mastodon import MastodonMalformedEventError, MastodonNetworkError, MastodonReadTimeout
 from mastodon.return_types import AttribAccessDict, Status, Notification, IdType, Conversation, Announcement, StreamReaction, try_cast_recurse
 from typing import Optional, Any

--- a/mastodon/timeline.py
+++ b/mastodon/timeline.py
@@ -1,6 +1,6 @@
 # timeline.py - endpoints for reading various different timelines
 
-from mastodon.errors import MastodonIllegalArgumentError, MastodonNotFoundError
+from mastodon.errors import MastodonIllegalArgumentError
 from mastodon.utility import api_version
 
 from mastodon.internals import Mastodon as Internals

--- a/mastodon/trends.py
+++ b/mastodon/trends.py
@@ -4,7 +4,7 @@ from mastodon.utility import api_version
 
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import Tag, Status, PreviewCard, NonPaginatableList
-from typing import Optional, Union
+from typing import Optional
 
 class Mastodon(Internals):
     ###

--- a/mastodon/types_base.py
+++ b/mastodon/types_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations # python < 3.9 compat
 import typing
-from typing import List, Union, Optional, Dict, Any, Tuple, Callable, get_type_hints, TypeVar, IO, Generic, ForwardRef
+from typing import List, Union, Optional, Dict, Any, get_type_hints, TypeVar, IO, Generic, ForwardRef
 from datetime import datetime, timezone
 import dateutil
 import dateutil.parser

--- a/mastodon/utility.py
+++ b/mastodon/utility.py
@@ -12,14 +12,13 @@ from mastodon.errors import MastodonAPIError, MastodonIllegalArgumentError, Mast
 from mastodon.compat import IMPL_HAS_BLURHASH, blurhash, IMPL_HAS_GRAPHEME, grapheme
 from mastodon.internals import Mastodon as Internals
 
-from mastodon.versions import parse_version_string, max_version, api_version
+from mastodon.versions import parse_version_string
 
-from typing import Optional, Union, Dict, Iterator, Tuple, List
+from typing import Optional, Union, Iterator, Tuple, List
 from mastodon.return_types import PaginatableList, PaginationInfo, PaginatableList, MediaAttachment
 from mastodon.types_base import Entity, try_cast
 
 from ._url_regex import url_regex
-import unicodedata
 
 _T = TypeVar("_T", bound=Entity)
 

--- a/srcgen/GenerateReturnTypes.ipynb
+++ b/srcgen/GenerateReturnTypes.ipynb
@@ -35,10 +35,6 @@
    "source": [
     "# Regular normal person imports\n",
     "import json\n",
-    "from datetime import datetime, timedelta, timezone\n",
-    "import copy\n",
-    "from typing import List, Union\n",
-    "import pickle as pkl\n",
     "\n",
     "# Mastodon.py imports\n",
     "from mastodon.return_types import *\n",
@@ -79,7 +75,6 @@
    "source": [
     "# Here you can test things manually during development\n",
     "# results = {}\n",
-    "import pickle as pkl\n",
     "#mastodon_soc.oauth_authorization_server_info()\n",
     "#mastodon_ico_admin.instance_terms_of_service(datetime(2025, 8, 17))"
    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import vcr
 
 # Set this to True to debug issues with tests
 DEBUG_REQUESTS = False

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 from datetime import datetime, timedelta
 from mastodon import MastodonIllegalArgumentError
 import hashlib

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,8 +1,7 @@
 import pytest
-import vcr      
 from mastodon.return_types import *
 from mastodon.types_base import real_issubclass, Entity
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import sys
       
 # "never record anything with admin in the URL" filter

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,4 @@
 import pytest
-import vcr
 from mastodon.Mastodon import MastodonAPIError
 import json
 from mastodon.return_types import Status, try_cast_recurse

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2,13 +2,11 @@ import pytest
 import itertools
 from mastodon.streaming import StreamListener, CallbackStreamListener
 from mastodon.Mastodon import MastodonMalformedEventError
-from mastodon import Mastodon
 
 import threading
 import time
 
 import select
-import sys
 
 streaming_is_patched = False
 real_connections = []

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,6 +1,4 @@
 import pytest
-import time
-import vcr
 
 
 @pytest.mark.vcr()

--- a/tests/test_zzz_revoke.py
+++ b/tests/test_zzz_revoke.py
@@ -1,5 +1,4 @@
 import pytest
-from mastodon.Mastodon import MastodonIllegalArgumentError
 from mastodon import Mastodon
 import vcr
 


### PR DESCRIPTION
This removes unused imports from both code and tests. This will often result
in lower memory usage and faster startup times.
