### PR TITLE
Remove unused imports

### DIFF
--- a/mastodon/Mastodon.py
+++ b/mastodon/Mastodon.py
@@ -1,26 +1,6 @@
 # coding: utf-8
 
-import json
-import base64
-import os
-import os.path
-import time
-import datetime
-import collections
-from contextlib import closing
-import requests
-from requests.models import urlencode
-import dateutil
-import dateutil.parser
-import re
-import copy
 
-
-from mastodon.compat import IMPL_HAS_CRYPTO, IMPL_HAS_ECE, IMPL_HAS_BLURHASH
-from mastodon.compat import cryptography, default_backend, ec, serialization
-from mastodon.compat import http_ece
-from mastodon.compat import blurhash
-from mastodon.compat import urlparse
 
 from mastodon.utility import parse_version_string, max_version, api_version
 from mastodon.utility import Mastodon as MastoUtility
@@ -28,10 +8,7 @@ from mastodon.utility import Mastodon as MastoUtility
 from mastodon.return_types import *
 from mastodon.errors import *
 
-from mastodon.defaults import _DEFAULT_TIMEOUT, _DEFAULT_SCOPES, _DEFAULT_STREAM_TIMEOUT, _DEFAULT_STREAM_RECONNECT_WAIT_SEC
-from mastodon.defaults import _SCOPE_SETS
 
-from mastodon.internals import Mastodon as Internals
 from mastodon.authentication import Mastodon as MastoAuthentication
 from mastodon.accounts import Mastodon as MastoAccounts
 from mastodon.instance import Mastodon as MastoInstance

--- a/mastodon/authentication.py
+++ b/mastodon/authentication.py
@@ -7,12 +7,11 @@ import os
 import time
 import collections
 
-from mastodon.errors import MastodonIllegalArgumentError, MastodonNetworkError, MastodonVersionError, MastodonAPIError, MastodonNotFoundError
+from mastodon.errors import MastodonIllegalArgumentError, MastodonNetworkError, MastodonVersionError, MastodonAPIError
 from mastodon.defaults import _DEFAULT_SCOPES, _SCOPE_SETS, _DEFAULT_TIMEOUT, _DEFAULT_USER_AGENT
 from mastodon.utility import parse_version_string, api_version
 
 from mastodon.internals import Mastodon as Internals
-from mastodon.utility import Mastodon as Utility
 from typing import List, Optional, Union, Tuple
 from mastodon.return_types import Application, AttribAccessDict, OAuthServerInfo, OAuthUserInfo
 from mastodon.compat import PurePath

--- a/mastodon/favourites.py
+++ b/mastodon/favourites.py
@@ -4,7 +4,7 @@ from mastodon.utility import api_version
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import Status, IdType, PaginatableList
 
-from typing import Optional, Union
+from typing import Optional
 
 class Mastodon(Internals):
     ###

--- a/mastodon/media.py
+++ b/mastodon/media.py
@@ -8,7 +8,7 @@ from mastodon.utility import api_version
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import MediaAttachment, PathOrFile, IdType
 
-from typing import Optional, Union, Tuple, List, Dict, Any
+from typing import Optional, Union, Tuple
 
 class Mastodon(Internals):
     ###

--- a/mastodon/streaming.py
+++ b/mastodon/streaming.py
@@ -9,7 +9,6 @@ try:
 except:
     pass
 
-from mastodon import Mastodon
 from mastodon.Mastodon import MastodonMalformedEventError, MastodonNetworkError, MastodonReadTimeout
 from mastodon.return_types import AttribAccessDict, Status, Notification, IdType, Conversation, Announcement, StreamReaction, try_cast_recurse
 from typing import Optional, Any

--- a/mastodon/timeline.py
+++ b/mastodon/timeline.py
@@ -1,6 +1,6 @@
 # timeline.py - endpoints for reading various different timelines
 
-from mastodon.errors import MastodonIllegalArgumentError, MastodonNotFoundError
+from mastodon.errors import MastodonIllegalArgumentError
 from mastodon.utility import api_version
 
 from mastodon.internals import Mastodon as Internals

--- a/mastodon/trends.py
+++ b/mastodon/trends.py
@@ -4,7 +4,7 @@ from mastodon.utility import api_version
 
 from mastodon.internals import Mastodon as Internals
 from mastodon.return_types import Tag, Status, PreviewCard, NonPaginatableList
-from typing import Optional, Union
+from typing import Optional
 
 class Mastodon(Internals):
     ###

--- a/mastodon/types_base.py
+++ b/mastodon/types_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations # python < 3.9 compat
 import typing
-from typing import List, Union, Optional, Dict, Any, Tuple, Callable, get_type_hints, TypeVar, IO, Generic, ForwardRef
+from typing import List, Union, Optional, Dict, Any, get_type_hints, TypeVar, IO, Generic, ForwardRef
 from datetime import datetime, timezone
 import dateutil
 import dateutil.parser
@@ -190,26 +190,6 @@ if sys.version_info < (3, 9):
     def resolve_type(t):
         # I'm sorry about this, but I cannot think of another way to make this work properly in versions below 3.9 that
         # cannot resolve forward references in a sane way
-        from mastodon.return_types import Account, AccountField, Role, CredentialAccountSource, \
-            Status, Quote, ShallowQuote, StatusEdit, FilterResult, StatusMention, \
-            ScheduledStatus, ScheduledStatusParams, Poll, PollOption, Conversation, Tag, \
-            TagHistory, CustomEmoji, Application, Relationship, Filter, FilterV2, \
-            Notification, Context, UserList, MediaAttachment, MediaAttachmentMetadataContainer, MediaAttachmentImageMetadata, \
-            MediaAttachmentVideoMetadata, MediaAttachmentAudioMetadata, MediaAttachmentFocusPoint, MediaAttachmentColors, PreviewCard, TrendingLinkHistory, \
-            PreviewCardAuthor, Search, SearchV2, Instance, InstanceConfiguration, InstanceURLs, \
-            InstanceV2, InstanceIcon, InstanceConfigurationV2, InstanceVapidKey, InstanceURLsV2, InstanceThumbnail, \
-            InstanceThumbnailVersions, InstanceStatistics, InstanceUsage, InstanceUsageUsers, RuleTranslation, Rule, \
-            InstanceRegistrations, InstanceContact, InstanceAccountConfiguration, InstanceStatusConfiguration, InstanceTranslationConfiguration, InstanceMediaConfiguration, \
-            InstancePollConfiguration, Nodeinfo, NodeinfoSoftware, NodeinfoServices, NodeinfoUsage, NodeinfoUsageUsers, \
-            NodeinfoMetadata, Activity, Report, AdminReport, WebPushSubscription, WebPushSubscriptionAlerts, \
-            PushNotification, Preferences, FeaturedTag, Marker, Announcement, Reaction, \
-            StreamReaction, FamiliarFollowers, AdminAccount, AdminIp, AdminMeasure, AdminMeasureData, \
-            AdminDimension, AdminDimensionData, AdminRetention, AdminCohort, AdminDomainBlock, AdminCanonicalEmailBlock, \
-            AdminDomainAllow, AdminEmailDomainBlock, AdminEmailDomainBlockHistory, AdminIpBlock, DomainBlock, ExtendedDescription, \
-            FilterKeyword, FilterStatus, IdentityProof, StatusSource, Suggestion, Translation, \
-            AccountCreationError, AccountCreationErrorDetails, AccountCreationErrorDetailsField, NotificationPolicy, NotificationPolicySummary, RelationshipSeveranceEvent, \
-            GroupedNotificationsResults, PartialAccountWithAvatar, NotificationGroup, AccountWarning, UnreadNotificationsCount, Appeal, \
-            NotificationRequest, SupportedLocale, OAuthServerInfo, OAuthUserInfo, TermsOfService
         if isinstance(t, ForwardRef):
             try:
                 t = t._evaluate(globals(), locals(), frozenset())


### PR DESCRIPTION
This removes unused imports in the `mastodon` directory while maintaining the ability to execute `pytest`.